### PR TITLE
支持自定义openai_api_base

### DIFF
--- a/bot/chatgpt/chat_gpt_bot.py
+++ b/bot/chatgpt/chat_gpt_bot.py
@@ -16,6 +16,7 @@ else:
 class ChatGPTBot(Bot):
     def __init__(self):
         openai.api_key = conf().get('open_ai_api_key')
+        openai.api_base = conf().get('open_ai_api_base')
         proxy = conf().get('proxy')
         if proxy:
             openai.proxy = proxy

--- a/bot/openai/open_ai_bot.py
+++ b/bot/openai/open_ai_bot.py
@@ -12,6 +12,7 @@ user_session = dict()
 class OpenAIBot(Bot):
     def __init__(self):
         openai.api_key = conf().get('open_ai_api_key')
+        openai.api_base = conf().get('open_ai_api_base')
 
 
     def reply(self, query, context=None):

--- a/config-template.json
+++ b/config-template.json
@@ -1,5 +1,6 @@
 {
   "open_ai_api_key": "YOUR API KEY",
+  "open_ai_api_base":"",
   "proxy": "",
   "single_chat_prefix": ["bot", "@bot"],
   "single_chat_reply_prefix": "[bot] ",


### PR DESCRIPTION
支持自定义openai_api_base

解决国内API被墙的问题，可以自定义使用自己的中转API

可以参考https://github.com/zhayujie/chatgpt-on-wechat/issues/446
这里可以设置成热心网友的
```
  "open_ai_api_base":"https://openai.nooc.ink/v1",
```
这样则无需科学上网便可以使用