### PR TITLE
支持Wechaty的自定义前缀+关键词生成AI图片的功能

### DIFF
--- a/channel/wechat/wechaty_channel.py
+++ b/channel/wechat/wechaty_channel.py
@@ -147,6 +147,13 @@ class WechatyChannel(Channel):
             match_prefix = (is_at and not config.get("group_at_off", False)) \
                            or self.check_prefix(content, config.get('group_chat_prefix')) \
                            or self.check_contain(content, config.get('group_chat_keyword'))
+            # Wechaty判断is_at为True，返回的内容是过滤掉@之后的内容；而is_at为False，则会返回完整的内容
+            # 故判断如果匹配到自定义前缀，则返回过滤掉前缀+空格后的内容，用于实现类似自定义+前缀触发生成AI图片的功能
+            prefixes = config.get('group_chat_prefix')
+            for prefix in prefixes:
+                if content.startswith(prefix):
+                    content = content.replace(prefix, '', 1).strip()
+                    break
             if ('ALL_GROUP' in config.get('group_name_white_list') or room_name in config.get(
                     'group_name_white_list') or self.check_contain(room_name, config.get(
                 'group_name_keyword_white_list'))) and match_prefix:


### PR DESCRIPTION
Wechaty判断`is_at`为`True`，返回的内容是过滤掉@之后的内容；而`is_at`为`False`，则会返回完整的内容
以上的情况导致`check_prefix`函数无法处理后者，拿到的内容是”前缀 关键词“，`check_prefix`需要拿到就是`关键词`才能判断是不是进入生成AI图片的功能
故判断如果匹配到自定义前缀，则返回过滤掉前缀+空格后的内容，用于实现类似自定义+前缀触发生成AI图片的功能