### PR TITLE
feature(rate-limit): 新增令牌桶类，用于主动限制调用gpt3.5, dalle接口频率

### DIFF
--- a/common/token_bucket.py
+++ b/common/token_bucket.py
@@ -1,0 +1,45 @@
+import threading
+import time
+
+
+class TokenBucket:
+    def __init__(self, tpm, timeout=None):
+        self.capacity = int(tpm)  # 令牌桶容量
+        self.tokens = 0  # 初始令牌数为0
+        self.rate = int(tpm) / 60  # 令牌每秒生成速率
+        self.timeout = timeout  # 等待令牌超时时间
+        self.cond = threading.Condition()  # 条件变量
+        self.is_running = True
+        # 开启令牌生成线程
+        threading.Thread(target=self._generate_tokens).start()
+
+    def _generate_tokens(self):
+        """生成令牌"""
+        while self.is_running:
+            with self.cond:
+                if self.tokens < self.capacity:
+                    self.tokens += 1
+                self.cond.notify()  # 通知获取令牌的线程
+            time.sleep(1 / self.rate)
+
+    def get_token(self):
+        """获取令牌"""
+        with self.cond:
+            while self.tokens <= 0:
+                flag = self.cond.wait(self.timeout)
+                if not flag:  # 超时
+                    return False
+            self.tokens -= 1
+        return True
+
+    def close(self):
+        self.is_running = False
+
+
+if __name__ == "__main__":
+    token_bucket = TokenBucket(20, None)  # 创建一个每分钟生产20个tokens的令牌桶
+    # token_bucket = TokenBucket(20, 0.1)
+    for i in range(3):
+        if token_bucket.get_token():
+            print(f"第{i+1}次请求成功")
+    token_bucket.close()


### PR DESCRIPTION
事情源于最近的commit: [增加hot_reload特性开关](https://github.com/zhayujie/chatgpt-on-wechat/commit/3ef7855384852d6733bd9af0e370a23d1a056568)
hot_reload不与服务器同步登录后接受消息的状态，如果和bot大量互动后使用hot_reload会短时间响应大量历史信息，这边观测到峰值达到200tps，远远超过了openai提供给免费用户的速率限制：
<img width="816" alt="截屏2023-03-20 22 26 55" src="https://user-images.githubusercontent.com/24581028/226370355-b1caf8c0-60db-4e58-9436-30e0e2cfb241.png">
为了避免被服务器识别为攻击行为，因此这边做了主动限速的commit，值得一提是RateLimitError错误处理是有必要的，因为openai也对tokens数做了限制
该功能为可选，可在config.json自由使用