### PR TITLE
fix： baidu voice init params type error

### DIFF
--- a/voice/baidu/baidu_voice.py
+++ b/voice/baidu/baidu_voice.py
@@ -43,9 +43,9 @@ class BaiduVoice(Voice):
                 with open(config_path, "r") as fr:
                     bconf = json.load(fr)
 
-            self.app_id = conf().get("baidu_app_id")
-            self.api_key = conf().get("baidu_api_key")
-            self.secret_key = conf().get("baidu_secret_key")
+            self.app_id = str(conf().get("baidu_app_id"))
+            self.api_key = str(conf().get("baidu_api_key"))
+            self.secret_key = str(conf().get("baidu_secret_key"))
             self.dev_id = conf().get("baidu_dev_pid")
             self.lang = bconf["lang"]
             self.ctp = bconf["ctp"]


### PR DESCRIPTION
百度语音的sdk初始化时会对参数进行strip，所以要保证是字符串。否则会报错

> [INFO][2023-06-09 11:04:01][bridge.py:30] - create bot baidu for voice_to_text
﻿[WARNING][2023-06-09 11:04:01][baidu_voice.py:59] - BaiduVoice init failed: 'int' object has no attribute 'strip', ignore
﻿[ERROR][2023-06-09 11:04:01][chat_channel.py:267] - Worker return exception: 'BaiduVoice' object has no attribute 'client'

https://github.com/Baidu-AIP/python-sdk/blob/e9add82014dec830a1b84c2b145a9faf40a84fc7/aip/base.py#LL42C11-L42C11