### PR TITLE
dockerfile fallback debian11,fix azure cognitiveservices speech error

### DIFF
--- a/docker/Dockerfile.latest
+++ b/docker/Dockerfile.latest
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 LABEL maintainer="foo@bar.com"
 ARG TZ='Asia/Shanghai'


### PR DESCRIPTION
Python 3.10-slim based Debian 12, using Azure TextToVoice may result in an error. the Speech SDK does not currently support OpenSSL 3.0, which is the default version in Ubuntu 22.04 and Debian 12