### PR TITLE
将ChatGPT on Wechat添加到Google Colab上并进行翻译。

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,13 @@ volumes:
   - ./config.json:/app/plugins/config.json
 ```
 
-### 4. Railway部署
+### 4. Google Colab谷歌合作實驗室
+
+> Google Colab 使用 Tesla T4 GPU 免費提供 12 小時的每日運行時間
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1NO_G4QrCIyWdOWkdYp5De1VHhjvXtpd7?usp=sharing)
+
+### 5. Railway部署
 
 > Railway 每月提供5刀和最多500小时的免费额度。 (07.11更新: 目前大部分账号已无法免费部署)
 


### PR DESCRIPTION
在您的浏览器中在Google Colab上运行ChatGPT on WeChat。
这样用户可以在他们的浏览器中尝试它，然后再在本地系统上运行。