### PR TITLE
实现claude对接配置中的 共享上下文开关

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 最新版本支持的功能如下：
 
 - [x] **多端部署：** 有多种部署方式可选择且功能完备，目前已支持个人微信，微信公众号和企业微信应用等部署方式
-- [x] **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3, GPT-3.5, GPT-4, Claude, 文心一言, 讯飞星火
+- [x] **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3, GPT-3.5, GPT-4, claude, 文心一言, 讯飞星火
 - [x] **语音识别：** 可识别语音消息，通过文字或语音回复，支持 azure, baidu, google, openai等多种语音模型
 - [x] **图片生成：** 支持图片生成 和 图生图（如照片修复），可选择 Dell-E, stable diffusion, replicate, midjourney模型
 - [x] **丰富插件：** 支持个性化插件扩展，已实现多角色切换、文字冒险、敏感词过滤、聊天记录总结等插件
@@ -27,7 +27,7 @@ Demo made by [Visionn](https://www.wangpc.cc/)
 <img width="240" src="./docs/images/contact.jpg">
 
 # 更新日志
->**2023.09.01：** 接入讯飞星火，Claude机器人
+>**2023.09.01：** 接入讯飞星火，claude机器人
 
 >**2023.08.08：** 接入百度文心一言模型，通过 [插件](https://github.com/zhayujie/chatgpt-on-wechat/tree/master/plugins/linkai) 支持 Midjourney 绘图
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ pip3 install azure-cognitiveservices-speech
 **6.Claude配置 (可选 model 为 claude 时生效)**
 
 + `claude_api_cookie`: claude官网聊天界面复制完整 cookie 字符串。
-+ `claude_uuid`: 可以指定对话id，默认新建对话实体。
 
 
 **7.xunfei配置 (可选 model 为 xunfei 时生效)**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 最新版本支持的功能如下：
 
 - [x] **多端部署：** 有多种部署方式可选择且功能完备，目前已支持个人微信，微信公众号和企业微信应用等部署方式
-- [x] **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3, GPT-3.5, GPT-4, 文心一言, 讯飞星火
+- [x] **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3, GPT-3.5, GPT-4, Claude, 文心一言, 讯飞星火
 - [x] **语音识别：** 可识别语音消息，通过文字或语音回复，支持 azure, baidu, google, openai等多种语音模型
 - [x] **图片生成：** 支持图片生成 和 图生图（如照片修复），可选择 Dell-E, stable diffusion, replicate, midjourney模型
 - [x] **丰富插件：** 支持个性化插件扩展，已实现多角色切换、文字冒险、敏感词过滤、聊天记录总结等插件
@@ -27,6 +27,7 @@ Demo made by [Visionn](https://www.wangpc.cc/)
 <img width="240" src="./docs/images/contact.jpg">
 
 # 更新日志
+>**2023.09.01：** 接入讯飞星火，Claude机器人
 
 >**2023.08.08：** 接入百度文心一言模型，通过 [插件](https://github.com/zhayujie/chatgpt-on-wechat/tree/master/plugins/linkai) 支持 Midjourney 绘图
 
@@ -157,7 +158,7 @@ pip3 install azure-cognitiveservices-speech
 
 **4.其他配置**
 
-+ `model`: 模型名称，目前支持 `gpt-3.5-turbo`, `text-davinci-003`, `gpt-4`, `gpt-4-32k`, `wenxin`  (其中gpt-4 api暂未完全开放，申请通过后可使用)
++ `model`: 模型名称，目前支持 `gpt-3.5-turbo`, `text-davinci-003`, `gpt-4`, `gpt-4-32k`, `wenxin` , `claude` ,  `xunfei`(其中gpt-4 api暂未完全开放，申请通过后可使用)
 + `temperature`,`frequency_penalty`,`presence_penalty`: Chat API接口参数，详情参考[OpenAI官方文档。](https://platform.openai.com/docs/api-reference/chat)
 + `proxy`：由于目前 `openai` 接口国内无法访问，需配置代理客户端的地址，详情参考  [#351](https://github.com/zhayujie/chatgpt-on-wechat/issues/351)
 + 对于图像生成，在满足个人或群组触发条件外，还需要额外的关键词前缀来触发，对应配置 `image_create_prefix `
@@ -174,6 +175,26 @@ pip3 install azure-cognitiveservices-speech
 + `use_linkai`: 是否使用LinkAI接口，开启后可国内访问，使用知识库和 `Midjourney` 绘画, 参考 [文档](https://link-ai.tech/platform/link-app/wechat)
 + `linkai_api_key`: LinkAI Api Key，可在 [控制台](https://chat.link-ai.tech/console/interface) 创建
 + `linkai_app_code`: LinkAI 应用code，选填
+
+**6.wenxin配置 (可选 model 为 wenxin 时生效)**
+
++ `baidu_wenxin_api_key`: 文心一言官网api key。
++ `baidu_wenxin_secret_key`: 文心一言官网secret key。
+
+
+**6.Claude配置 (可选 model 为 claude 时生效)**
+
++ `claude_api_cookie`: claude官网聊天界面复制完整 cookie 字符串。
++ `claude_uuid`: 可以指定对话id，默认新建对话实体。
+
+
+**7.xunfei配置 (可选 model 为 xunfei 时生效)**
+
++ `xunfei_app_id`: 讯飞星火app id。
++ `xunfei_api_key`: 讯飞星火 api key。
++ `xunfei_api_secret`: 讯飞星火 secret。
+
+
 
 **本说明文档可能会未及时更新，当前所有可选的配置项均在该[`config.py`](https://github.com/zhayujie/chatgpt-on-wechat/blob/master/config.py)中列出。**
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ pip3 install azure-cognitiveservices-speech
 **6.Claude配置 (可选 model 为 claude 时生效)**
 
 + `claude_api_cookie`: claude官网聊天界面复制完整 cookie 字符串。
++ `claude_uuid`: 可以指定对话id，默认新建对话实体。
 
 
 **7.xunfei配置 (可选 model 为 xunfei 时生效)**

--- a/bot/claude/claude_ai_bot.py
+++ b/bot/claude/claude_ai_bot.py
@@ -42,7 +42,6 @@ class ClaudeAIBot(Bot, OpenAIImage):
             con_uuid = self.generate_uuid()
             self.create_new_chat(con_uuid)
 
-
     def get_organization_id(self):
         url = "https://claude.ai/api/organizations"
         headers = {
@@ -78,7 +77,6 @@ class ClaudeAIBot(Bot, OpenAIImage):
 
     def get_organization_id(self):
         url = "https://claude.ai/api/organizations"
-
         headers = {
             'User-Agent':
                 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0',
@@ -97,7 +95,6 @@ class ClaudeAIBot(Bot, OpenAIImage):
             uuid = res[0]['uuid']
         except:
             print(response.text)
-
         return uuid
 
     def conversation_share_check(self,session_id):
@@ -145,7 +142,6 @@ class ClaudeAIBot(Bot, OpenAIImage):
             session_id = context["session_id"]
             session = self.sessions.session_query(query, session_id)
             con_uuid = self.conversation_share_check(session_id)
-
             model = conf().get("model") or "gpt-3.5-turbo"
             # remove system message
             if session.messages[0].get("role") == "system":

--- a/bot/claude/claude_ai_session
+++ b/bot/claude/claude_ai_session
@@ -1,0 +1,9 @@
+from bot.session_manager import Session
+
+
+class ClaudeAiSession(Session):
+    def __init__(self, session_id, system_prompt=None, model="claude"):
+        super().__init__(session_id, system_prompt)
+        self.model = model
+        # claude逆向不支持role prompt
+        # self.reset()

--- a/config.py
+++ b/config.py
@@ -124,7 +124,8 @@ available_setting = {
     # wework的通用配置
     "wework_smart": True  # 配置wework是否使用已登录的企业微信，False为多开
     #claude 配置
-    "claude_api_cookie":""
+    "claude_api_cookie":"",
+    "claude_uuid":""
 }
 
 

--- a/config.py
+++ b/config.py
@@ -124,8 +124,7 @@ available_setting = {
     # wework的通用配置
     "wework_smart": True  # 配置wework是否使用已登录的企业微信，False为多开
     #claude 配置
-    "claude_api_cookie":"",
-    "claude_uuid":""
+    "claude_api_cookie":""
 }
 
 


### PR DESCRIPTION
1.之前传的claude 忘记实现共享上下文的开关功能对接,因为claude接口是指定id实现上下文对应而非message形式，采用了自定义conversation_share_check函数 进行 session_id 与 历史对话id的比对(用户透明)，总开关与项目的 group_chat_in_one_session参数保持一致。
2.更新了下文档
3.美化此接口部分代码格式、缩进