### PR TITLE
添加 chatgpt_hack  机器人& 逆向免 api_key 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Demo made by [Visionn](https://www.wangpc.cc/)
 <img width="240" src="./docs/images/contact.jpg">
 
 # 更新日志
->**2023.09.06：** 增加 [chatgpt_hack](1401) 机器人，逆向免apikey同步openai官网聊天功能
+>**2023.09.06：** 增加 [chatgpt_hack](https://github.com/zhayujie/chatgpt-on-wechat/pull/1401) 机器人，逆向免apikey同步openai官网聊天功能
 
->**2023.09.01：** 增加 [企微个人号](#1385) 通道，[claude](1382)，讯飞星火模型
+>**2023.09.01：** 增加 [企微个人号](#1385) 通道，[claude](https://github.com/zhayujie/chatgpt-on-wechat/pull/1382)，讯飞星火模型
 
 >**2023.08.08：** 接入百度文心一言模型，通过 [插件](https://github.com/zhayujie/chatgpt-on-wechat/tree/master/plugins/linkai) 支持 Midjourney 绘图
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pip3 install azure-cognitiveservices-speech
 # config.json文件内容示例
 {
   "open_ai_api_key": "YOUR API KEY",                          # 填入上面创建的 OpenAI API KEY
-  "model": "gpt-3.5-turbo",                                   # 模型名称, 支持 gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-4, chatgpt_hack,claude, wenxin, xunfei
+  "model": "gpt-3.5-turbo",                                   # 模型名称, 支持 gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-4, chatgpt_hack, claude, wenxin, xunfei
   "proxy": "",                                                # 代理客户端的ip和端口，国内环境开启代理的需要填写该项，如 "127.0.0.1:7890"
   "single_chat_prefix": ["bot", "@bot"],                      # 私聊时文本需要包含该前缀才能触发机器人回复
   "single_chat_reply_prefix": "[bot] ",                       # 私聊时自动回复的前缀，用于区分真人

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Demo made by [Visionn](https://www.wangpc.cc/)
 <img width="240" src="./docs/images/contact.jpg">
 
 # 更新日志
->**2023.09.06：** 增加 chatgpt_hack 机器人，逆向免apikey同步openai官网聊天功能
+>**2023.09.06：** 增加 [chatgpt_hack](1401) 机器人，逆向免apikey同步openai官网聊天功能
 
->**2023.09.01：** 增加 [企微个人号](#1385) 通道，[claude](1388)，讯飞星火模型
+>**2023.09.01：** 增加 [企微个人号](#1385) 通道，[claude](1382)，讯飞星火模型
 
 >**2023.08.08：** 接入百度文心一言模型，通过 [插件](https://github.com/zhayujie/chatgpt-on-wechat/tree/master/plugins/linkai) 支持 Midjourney 绘图
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 最新版本支持的功能如下：
 
 - [x] **多端部署：** 有多种部署方式可选择且功能完备，目前已支持个人微信，微信公众号和企业微信应用等部署方式
-- [x] **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3.5, GPT-4, claude, 文心一言, 讯飞星火
+- [x] **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3.5, GPT-4, chatgpt_hack, claude, 文心一言, 讯飞星火
 - [x] **语音识别：** 可识别语音消息，通过文字或语音回复，支持 azure, baidu, google, openai等多种语音模型
 - [x] **图片生成：** 支持图片生成 和 图生图（如照片修复），可选择 Dell-E, stable diffusion, replicate, midjourney模型
 - [x] **丰富插件：** 支持个性化插件扩展，已实现多角色切换、文字冒险、敏感词过滤、聊天记录总结等插件
@@ -27,6 +27,8 @@ Demo made by [Visionn](https://www.wangpc.cc/)
 <img width="240" src="./docs/images/contact.jpg">
 
 # 更新日志
+>**2023.09.06：** 增加 chatgpt_hack 机器人，逆向免apikey同步openai官网聊天功能
+
 >**2023.09.01：** 增加 [企微个人号](#1385) 通道，[claude](1388)，讯飞星火模型
 
 >**2023.08.08：** 接入百度文心一言模型，通过 [插件](https://github.com/zhayujie/chatgpt-on-wechat/tree/master/plugins/linkai) 支持 Midjourney 绘图

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pip3 install azure-cognitiveservices-speech
 # config.json文件内容示例
 {
   "open_ai_api_key": "YOUR API KEY",                          # 填入上面创建的 OpenAI API KEY
-  "model": "gpt-3.5-turbo",                                   # 模型名称, 支持 gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-4, wenxin, xunfei
+  "model": "gpt-3.5-turbo",                                   # 模型名称, 支持 gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-4, chatgpt_hack,claude, wenxin, xunfei
   "proxy": "",                                                # 代理客户端的ip和端口，国内环境开启代理的需要填写该项，如 "127.0.0.1:7890"
   "single_chat_prefix": ["bot", "@bot"],                      # 私聊时文本需要包含该前缀才能触发机器人回复
   "single_chat_reply_prefix": "[bot] ",                       # 私聊时自动回复的前缀，用于区分真人

--- a/bot/bot_factory.py
+++ b/bot/bot_factory.py
@@ -40,6 +40,10 @@ def create_bot(bot_type):
         from bot.linkai.link_ai_bot import LinkAIBot
         return LinkAIBot()
 
+    elif bot_type == const.CHATGPTHACKAI:
+        from bot.chatgpt_hack.chatgpt_hack_bot import ChatgptHackBot
+        return ChatgptHackBot()
+
     elif bot_type == const.CLAUDEAI:
         from bot.claude.claude_ai_bot import ClaudeAIBot
         return ClaudeAIBot()

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -29,24 +29,12 @@ class ChatgptHackBot(Bot, OpenAIImage):
         self.paren_message_id = ""
         self.conversation_id = ""
         self.headers = {
-            'authority': 'chat.openai.com',
-            'accept': 'text/event-stream',
-            'accept-language': 'en-US',
-            'authorization': self.autho,
-            'cache-control': 'no-cache',
-            'content-type': 'application/json',
-            'cookie': "",
-            'origin': 'https://chat.openai.com',
-            'pragma': 'no-cache',
-            'referer': 'https://chat.openai.com',
-            'sec-ch-ua': '"Chromium";v="116", "Not)A;Brand";v="24", "Microsoft Edge";v="116"',
-            'sec-ch-ua-mobile': '?0',
-            'sec-ch-ua-platform': '"Windows"',
-            'sec-fetch-dest': 'empty',
-            'sec-fetch-mode': 'cors',
-            'sec-fetch-site': 'same-origin',
-            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.69'
-        }
+    'authority': 'chat.openai.com',
+    'accept': 'text/event-stream',
+    'accept-language': 'en-US',
+    'authorization': self.autho,
+    'content-type': 'application/json',
+}
         self.payload = {"action":"next",
                                 "messages":[{"id":self.generate_uuid(),
                                              "author":{"role":"system"},

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -136,5 +136,5 @@ class ChatgptHackBot(Bot, OpenAIImage):
         except Exception as e:
             logger.exception(e)
             time.sleep(2)
-            logger.warn(f"[CLAUDE] do retry, times={retry_count}")
+            logger.warn(f"[CHATGPTHACKAI] do retry, times={retry_count}")
             return self._chat(query, context, retry_count + 1)

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -4,6 +4,8 @@ import json
 import uuid
 from curl_cffi import requests
 from bot.bot import Bot
+
+
 from bot.chatgpt_hack.chatgpt_hack_session import ChatgptHackSession
 from bot.openai.open_ai_image import OpenAIImage
 from bot.session_manager import SessionManager
@@ -19,7 +21,6 @@ class ChatgptHackBot(Bot, OpenAIImage):
         self.sessions = SessionManager(ChatgptHackSession, model=conf().get("model") or "gpt-3.5-turbo")
         self.proxy = conf().get("proxy")
         self.con_uuid_dic = {}
-        self.cookie = conf().get("chatgpt_hack_cookie")
         self.autho = conf().get("chatgpt_hack_autho")
         if self.proxy:
             self.proxies = {
@@ -38,7 +39,7 @@ class ChatgptHackBot(Bot, OpenAIImage):
             'authorization': self.autho,
             'cache-control': 'no-cache',
             'content-type': 'application/json',
-            'cookie': self.cookie,
+            'cookie': "",
             'origin': 'https://chat.openai.com',
             'pragma': 'no-cache',
             'referer': 'https://chat.openai.com',

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -20,15 +20,13 @@ class ChatgptHackBot(Bot, OpenAIImage):
         self.url = "https://chat.openai.com/backend-api/conversation"
         self.sessions = SessionManager(ChatgptHackSession, model=conf().get("model") or "gpt-3.5-turbo")
         self.proxy = conf().get("proxy")
-        self.con_uuid_dic = {}
         self.autho = conf().get("chatgpt_hack_autho")
         if self.proxy:
             self.proxies = {
                 "http": self.proxy,
                 "https": self.proxy
             }
-        else:
-            self.proxies = None
+        else:self.proxies = None
         self.error = ""
         self.paren_message_id = ""
         self.conversation_id = ""
@@ -60,7 +58,6 @@ class ChatgptHackBot(Bot, OpenAIImage):
         return formatted_uuid
 
     def create_conversation(self,prompt):
-
         payload = {"action":"next",
                    "messages":[{"id":self.generate_uuid(),
                                 "author":{"role":"system"},

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -1,0 +1,160 @@
+import re
+import time
+import json
+import uuid
+from curl_cffi import requests
+from bot.bot import Bot
+from bot.chatgpt_hack.chatgpt_hack_session import ChatgptHackSession
+from bot.openai.open_ai_image import OpenAIImage
+from bot.session_manager import SessionManager
+from bridge.context import Context, ContextType
+from bridge.reply import Reply, ReplyType
+from common.log import logger
+from config import conf
+
+class ChatgptHackBot(Bot, OpenAIImage):
+    def __init__(self):
+        super().__init__()
+        self.url = "https://chat.openai.com/backend-api/conversation"
+        self.sessions = SessionManager(ChatgptHackSession, model=conf().get("model") or "gpt-3.5-turbo")
+        self.proxy = conf().get("proxy")
+        self.con_uuid_dic = {}
+        self.cookie = conf().get("chatgpt_hack_cookie")
+        self.autho = conf().get("chatgpt_hack_autho")
+        if self.proxy:
+            self.proxies = {
+                "http": self.proxy,
+                "https": self.proxy
+            }
+        else:
+            self.proxies = None
+        self.error = ""
+        self.paren_message_id = ""
+        self.conversation_id = ""
+        self.headers = {
+            'authority': 'chat.openai.com',
+            'accept': 'text/event-stream',
+            'accept-language': 'en-US',
+            'authorization': self.autho,
+            'cache-control': 'no-cache',
+            'content-type': 'application/json',
+            'cookie': self.cookie,
+            'origin': 'https://chat.openai.com',
+            'pragma': 'no-cache',
+            'referer': 'https://chat.openai.com',
+            'sec-ch-ua': '"Chromium";v="116", "Not)A;Brand";v="24", "Microsoft Edge";v="116"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Windows"',
+            'sec-fetch-dest': 'empty',
+            'sec-fetch-mode': 'cors',
+            'sec-fetch-site': 'same-origin',
+            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 Edg/116.0.1938.69'
+        }
+        self.create_conversation(conf().get("character_desc", ""))
+
+    def generate_uuid(self):
+        random_uuid = uuid.uuid4()
+        random_uuid_str = str(random_uuid)
+        formatted_uuid = f"{random_uuid_str[0:8]}-{random_uuid_str[9:13]}-{random_uuid_str[14:18]}-{random_uuid_str[19:23]}-{random_uuid_str[24:]}"
+        return formatted_uuid
+
+    def create_conversation(self,prompt):
+
+        payload = {"action":"next",
+                   "messages":[{"id":self.generate_uuid(),
+                                "author":{"role":"system"},
+                                "content":{"content_type":"text","parts":[""]}}],
+                   "parent_message_id":self.generate_uuid(),
+                   "model":"text-davinci-002",
+                   "timezone_offset_min":-480,"suggestions":[],
+                   "history_and_training_disabled":False,
+                   "arkose_token":None}
+        payload["messages"][0]["content"]["parts"] = [prompt]
+        try:
+            base_payload = json.dumps(payload)
+            r = requests.post(self.url, headers=self.headers, impersonate="chrome110", proxies =self.proxies, data = base_payload, verify = False)
+            origin_res = r.text.encode('utf-8').decode('unicode_escape')
+            res = json.loads(origin_res.split("data:")[-2].strip())
+            con_id = res["conversation_id"]
+            message_id = res["message_id"]
+            self.paren_message_id = message_id
+            self.conversation_id = con_id
+        except Exception as file:
+            logger.error("[CHATGPTHACKAI] faied to create new conversion!")
+            return None,None
+
+    def send_message(self,role, message, parent_message_id, conversation_id):
+        payload = json.dumps({"action":"next",
+                              "messages":[
+                                  {"id": self.generate_uuid(),
+                                   "author":{"role": role},
+                                   "content":{"content_type":"text","parts":[message]},"metadata":{}}],
+                              "conversation_id":conversation_id,
+                              "parent_message_id":parent_message_id,
+                              "model":"text-davinci-002-render-sha",
+                              "timezone_offset_min":-480,"suggestions":[],
+                              "history_and_training_disabled":False,
+                              "arkose_token":None})
+        r = requests.post(self.url, headers=self.headers, impersonate="chrome110", proxies =self.proxies, data = payload)
+        try:
+            res = r.text.encode('utf-8').decode('unicode_escape').replace("\n","\\n")
+            result = json.loads(re.findall('data: (?:.|\n)*?"error": null}',res)[-1][6:])
+            answer = result["message"]["content"]["parts"][0]
+            message_id = result["message"]["id"]
+            self.paren_message_id = message_id
+        except Exception as file:
+            logger.error("[CHATGPTHACKAI] faied to send question!")
+            return None
+        return answer
+
+    def reply(self, query, context: Context = None) -> Reply:
+        if context.type == ContextType.TEXT:
+            return self._chat(query, context)
+        elif context.type == ContextType.IMAGE_CREATE:
+            ok, res = self.create_img(query, 0)
+            if ok:
+                reply = Reply(ReplyType.IMAGE_URL, res)
+            else:
+                reply = Reply(ReplyType.ERROR, res)
+            return reply
+        else:
+            reply = Reply(ReplyType.ERROR, "Bot不支持处理{}类型的消息".format(context.type))
+            return reply
+
+    def _chat(self, query, context, retry_count=0) -> Reply:
+        """
+        发起对话请求
+        :param query: 请求提示词
+        :param context: 对话上下文
+        :param retry_count: 当前递归重试次数
+        :return: 回复
+        """
+        if retry_count >= 2:
+            # exit from retry 2 times
+            logger.error("[CHATGPTHACKAI] failed after maximum number of retry times")
+            return Reply(ReplyType.ERROR, "请再问我一次吧")
+
+        try:
+            session_id = context["session_id"]
+
+            session = self.sessions.session_query(query, session_id)
+
+            model = conf().get("model") or "gpt-3.5-turbo"
+            # remove system message
+            if session.messages[0].get("role") == "system":
+                if model == "wenxin" or model == "claude" or model == "chatgpt_hack":
+                    session.messages.pop(0)
+            logger.info(f"[CHATGPTHACKAI] query={query}")
+            answer = self.send_message("user", query, self.paren_message_id, self.conversation_id)
+            if answer:
+                logger.info(f"[CHATGPTHACKAI] reply={answer}, total_tokens=invisible")
+                self.sessions.session_reply(answer, session_id, 100)
+                return Reply(ReplyType.TEXT, answer)
+            else:
+                return Reply(ReplyType.ERROR, "返回失败")
+
+        except Exception as e:
+            logger.exception(e)
+            time.sleep(2)
+            logger.warn(f"[CLAUDE] do retry, times={retry_count}")
+            return self._chat(query, context, retry_count + 1)

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -12,6 +12,7 @@ from bridge.reply import Reply, ReplyType
 from common.log import logger
 from config import conf
 
+
 class ChatgptHackBot(Bot, OpenAIImage):
     def __init__(self):
         super().__init__()

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -4,8 +4,6 @@ import json
 import uuid
 from curl_cffi import requests
 from bot.bot import Bot
-
-
 from bot.chatgpt_hack.chatgpt_hack_session import ChatgptHackSession
 from bot.openai.open_ai_image import OpenAIImage
 from bot.session_manager import SessionManager

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -81,6 +81,7 @@ class ChatgptHackBot(Bot, OpenAIImage):
             self.paren_message_id = message_id
             self.conversation_id = con_id
         except Exception as file:
+            logger.error("[CHATGPTHACKAI] origin_error: {}".format(origin_res))
             logger.error("[CHATGPTHACKAI] faied to create new conversion!")
             return None,None
 

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -137,9 +137,7 @@ class ChatgptHackBot(Bot, OpenAIImage):
 
         try:
             session_id = context["session_id"]
-
             session = self.sessions.session_query(query, session_id)
-
             model = conf().get("model") or "gpt-3.5-turbo"
             # remove system message
             if session.messages[0].get("role") == "system":

--- a/bot/chatgpt_hack/chatgpt_hack_bot.py
+++ b/bot/chatgpt_hack/chatgpt_hack_bot.py
@@ -30,12 +30,12 @@ class ChatgptHackBot(Bot, OpenAIImage):
         self.paren_message_id = ""
         self.conversation_id = ""
         self.headers = {
-    'authority': 'chat.openai.com',
-    'accept': 'text/event-stream',
-    'accept-language': 'en-US',
-    'authorization': self.autho,
-    'content-type': 'application/json',
-}
+            'authority': 'chat.openai.com',
+            'accept': 'text/event-stream',
+            'accept-language': 'en-US',
+            'authorization': self.autho,
+            'content-type': 'application/json',
+        }
         self.payload = {"action":"next",
                                 "messages":[{"id":self.generate_uuid(),
                                              "author":{"role":"system"},

--- a/bot/chatgpt_hack/chatgpt_hack_session.py
+++ b/bot/chatgpt_hack/chatgpt_hack_session.py
@@ -12,5 +12,3 @@ class ChatgptHackSession(Session):
     def __init__(self, session_id, system_prompt=None, model="chatgpt_hack"):
         super().__init__(session_id, system_prompt)
         self.model = model
-        # claude逆向不支持role prompt
-        # self.reset()

--- a/bot/chatgpt_hack/chatgpt_hack_session.py
+++ b/bot/chatgpt_hack/chatgpt_hack_session.py
@@ -1,0 +1,16 @@
+from bot.session_manager import Session
+
+"""
+    e.g.  [{"id":23d977a3-2ffb-43a8-8c19-5f2f29c1fc7a,
+                                "author":{"role":"system"},
+                                "content":{"content_type":"text","parts":[""]}},
+                               {"id":awdf5578-2ffb-43ae-8cg9-5f2qwe48fc7a,
+                                "author":{"role":"user"},
+                                "content":{"content_type":"text","parts":[create_message]},"metadata":{}}]
+"""
+class ChatgptHackSession(Session):
+    def __init__(self, session_id, system_prompt=None, model="chatgpt_hack"):
+        super().__init__(session_id, system_prompt)
+        self.model = model
+        # claude逆向不支持role prompt
+        # self.reset()

--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -31,6 +31,8 @@ class Bridge(object):
             self.btype["chat"] = const.LINKAI
         if model_type in ["claude"]:
             self.btype["chat"] = const.CLAUDEAI
+        if model_type in ["chatgpt_hack"]:
+            self.btype["chat"] = const.CHATGPTHACKAI
         self.bots = {}
 
     def get_bot(self, typename):

--- a/common/const.py
+++ b/common/const.py
@@ -7,6 +7,6 @@ CHATGPTONAZURE = "chatGPTOnAzure"
 LINKAI = "linkai"
 
 VERSION = "1.3.0"
-
+CHATGPTHACKAI = "chatgpt_hack"
 CLAUDEAI = "claude"
-MODEL_LIST = ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "wenxin", "xunfei","claude"]
+MODEL_LIST = ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "wenxin", "xunfei","claude","chatgpt_hack"]

--- a/common/const.py
+++ b/common/const.py
@@ -5,8 +5,8 @@ BAIDU = "baidu"
 XUNFEI = "xunfei"
 CHATGPTONAZURE = "chatGPTOnAzure"
 LINKAI = "linkai"
-
-VERSION = "1.3.0"
 CHATGPTHACKAI = "chatgpt_hack"
 CLAUDEAI = "claude"
+
+VERSION = "1.3.0"
 MODEL_LIST = ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "wenxin", "xunfei","claude","chatgpt_hack"]

--- a/config-template.json
+++ b/config-template.json
@@ -4,7 +4,6 @@
   "channel_type": "wx",
   "proxy": "",
   "hot_reload": false,
-  "claude_uuid": "",
   "single_chat_prefix": [
     "bot",
     "@bot"

--- a/config-template.json
+++ b/config-template.json
@@ -1,6 +1,6 @@
 {
   "open_ai_api_key": "YOUR API KEY",
-  "model": "",
+  "model": "gpt-3.5-turbo",
   "channel_type": "wx",
   "proxy": "",
   "hot_reload": false,

--- a/config-template.json
+++ b/config-template.json
@@ -1,9 +1,10 @@
 {
   "open_ai_api_key": "YOUR API KEY",
-  "model": "gpt-3.5-turbo",
+  "model": "",
   "channel_type": "wx",
   "proxy": "",
   "hot_reload": false,
+  "claude_uuid": "",
   "single_chat_prefix": [
     "bot",
     "@bot"

--- a/config-template.json
+++ b/config-template.json
@@ -1,10 +1,10 @@
 {
   "open_ai_api_key": "YOUR API KEY",
-  "model": "chatgpt_hack",
+  "model": "",
   "channel_type": "wx",
-  "proxy": "127.0.0.1:33210",
-  "hot_reload": true,
-  "chatgpt_hack_autho": "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1UaEVOVUpHTkVNMVFURTRNMEZCTWpkQ05UZzVNRFUxUlRVd1FVSkRNRU13UmtGRVFrRXpSZyJ9.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL3Byb2ZpbGUiOnsiZW1haWwiOiJjaG9jb2xhdGVjaGVubm5AZ21haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWV9LCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsidXNlcl9pZCI6InVzZXItS1V6SmFSYUxTY3FWM0FpeWZNdnJwSUtHIn0sImlzcyI6Imh0dHBzOi8vYXV0aDAub3BlbmFpLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDEwMTA5OTc2MzIzOTI1Mjg1MTE3MCIsImF1ZCI6WyJodHRwczovL2FwaS5vcGVuYWkuY29tL3YxIiwiaHR0cHM6Ly9vcGVuYWkub3BlbmFpLmF1dGgwYXBwLmNvbS91c2VyaW5mbyJdLCJpYXQiOjE2OTM0NTM3MTQsImV4cCI6MTY5NDY2MzMxNCwiYXpwIjoiVGRKSWNiZTE2V29USHROOTVueXl3aDVFNHlPbzZJdEciLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIG1vZGVsLnJlYWQgbW9kZWwucmVxdWVzdCBvcmdhbml6YXRpb24ucmVhZCBvcmdhbml6YXRpb24ud3JpdGUgb2ZmbGluZV9hY2Nlc3MifQ.kGYRrn956ifLfKmNqG03ni-dURQfhWl-PmODcT70ycs52TLVm0NnpkzPtbWKmFzeS8eESaUDRBgs57IJHkPRaDOpxlhoRFftzCzSoaeKB-hVFHEbz7WYKtYwya8rdifjpwek8Ow9S26i2TOFPS_OyvRz2NgAm43DVCKeazBHgDDMGIvNI1mwr16qYR5g3xVOE5vcmk9XuK5dZF0BOHFpxkhX4tz6zZ430FA2iqDrXXQYOWQeaP44vcMFvfcbkKl3huJL-PsIUHrCWs_u1eAKMZQMn6FKbhQN-VcTbN91sS9TS_Cmwc38FhWdpZ32LvRW8Yb3EFJUbvQb4rgfSWCVVw",
+  "proxy": "",
+  "hot_reload": false,
+  "claude_uuid": "",
   "single_chat_prefix": [
     "bot",
     "@bot"
@@ -15,10 +15,10 @@
   ],
   "group_name_white_list": [
     "ChatGPT测试群",
-    "高中数学应用题"
+    "ChatGPT测试群2"
   ],
   "group_chat_in_one_session": [
-    "高中数学应用题"
+    "ChatGPT测试群"
   ],
   "image_create_prefix": [
     "画",

--- a/config-template.json
+++ b/config-template.json
@@ -1,10 +1,10 @@
 {
   "open_ai_api_key": "YOUR API KEY",
-  "model": "",
+  "model": "chatgpt_hack",
   "channel_type": "wx",
-  "proxy": "",
-  "hot_reload": false,
-  "claude_uuid": "",
+  "proxy": "127.0.0.1:33210",
+  "hot_reload": true,
+  "chatgpt_hack_autho": "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1UaEVOVUpHTkVNMVFURTRNMEZCTWpkQ05UZzVNRFUxUlRVd1FVSkRNRU13UmtGRVFrRXpSZyJ9.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL3Byb2ZpbGUiOnsiZW1haWwiOiJjaG9jb2xhdGVjaGVubm5AZ21haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWV9LCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsidXNlcl9pZCI6InVzZXItS1V6SmFSYUxTY3FWM0FpeWZNdnJwSUtHIn0sImlzcyI6Imh0dHBzOi8vYXV0aDAub3BlbmFpLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDEwMTA5OTc2MzIzOTI1Mjg1MTE3MCIsImF1ZCI6WyJodHRwczovL2FwaS5vcGVuYWkuY29tL3YxIiwiaHR0cHM6Ly9vcGVuYWkub3BlbmFpLmF1dGgwYXBwLmNvbS91c2VyaW5mbyJdLCJpYXQiOjE2OTM0NTM3MTQsImV4cCI6MTY5NDY2MzMxNCwiYXpwIjoiVGRKSWNiZTE2V29USHROOTVueXl3aDVFNHlPbzZJdEciLCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIG1vZGVsLnJlYWQgbW9kZWwucmVxdWVzdCBvcmdhbml6YXRpb24ucmVhZCBvcmdhbml6YXRpb24ud3JpdGUgb2ZmbGluZV9hY2Nlc3MifQ.kGYRrn956ifLfKmNqG03ni-dURQfhWl-PmODcT70ycs52TLVm0NnpkzPtbWKmFzeS8eESaUDRBgs57IJHkPRaDOpxlhoRFftzCzSoaeKB-hVFHEbz7WYKtYwya8rdifjpwek8Ow9S26i2TOFPS_OyvRz2NgAm43DVCKeazBHgDDMGIvNI1mwr16qYR5g3xVOE5vcmk9XuK5dZF0BOHFpxkhX4tz6zZ430FA2iqDrXXQYOWQeaP44vcMFvfcbkKl3huJL-PsIUHrCWs_u1eAKMZQMn6FKbhQN-VcTbN91sS9TS_Cmwc38FhWdpZ32LvRW8Yb3EFJUbvQb4rgfSWCVVw",
   "single_chat_prefix": [
     "bot",
     "@bot"
@@ -15,10 +15,10 @@
   ],
   "group_name_white_list": [
     "ChatGPT测试群",
-    "ChatGPT测试群2"
+    "高中数学应用题"
   ],
   "group_chat_in_one_session": [
-    "ChatGPT测试群"
+    "高中数学应用题"
   ],
   "image_create_prefix": [
     "画",

--- a/config.py
+++ b/config.py
@@ -62,6 +62,9 @@ available_setting = {
     # claude 配置
     "claude_api_cookie": "",
     "claude_uuid": "",
+    #chatgpt_hack 配置
+    "chatgpt_hack_cookie": "",
+    "chatgpt_hack_autho": "",
     # wework的通用配置
     "wework_smart": True,  # 配置wework是否使用已登录的企业微信，False为多开
     # 语音设置

--- a/config.py
+++ b/config.py
@@ -60,10 +60,10 @@ available_setting = {
     "xunfei_api_key": "",  # 讯飞 API key
     "xunfei_api_secret": "",  # 讯飞 API secret
     # claude 配置
-    "claude_api_cookie": "",
-    "claude_uuid": "",
+    "claude_api_cookie": "", # claude cookie
+    "claude_uuid": "", # 可选，指定对话uuid，默认新建
     #chatgpt_hack 配置
-    "chatgpt_hack_autho": "",
+    "chatgpt_hack_autho": "", #chatgpt 官网 Authorization 参数
     # wework的通用配置
     "wework_smart": True,  # 配置wework是否使用已登录的企业微信，False为多开
     # 语音设置

--- a/config.py
+++ b/config.py
@@ -63,7 +63,6 @@ available_setting = {
     "claude_api_cookie": "",
     "claude_uuid": "",
     #chatgpt_hack 配置
-    "chatgpt_hack_cookie": "",
     "chatgpt_hack_autho": "",
     # wework的通用配置
     "wework_smart": True,  # 配置wework是否使用已登录的企业微信，False为多开

--- a/config.py
+++ b/config.py
@@ -61,7 +61,7 @@ available_setting = {
     "xunfei_api_secret": "",  # 讯飞 API secret
     # claude 配置
     "claude_api_cookie": "", # claude cookie
-    "claude_uuid": "", # 可选，指定对话uuid，默认新建
+    "claude_uuid": "", # 指定对话uuid，默认新建
     #chatgpt_hack 配置
     "chatgpt_hack_autho": "", #chatgpt 官网 Authorization 参数
     # wework的通用配置


### PR DESCRIPTION
# 添加 chatgpt_hack （纯api逆向）bot 

与chatgpt官网网页聊天同步，参数持续性估测为14天，需openai ai支持的海外网络，不影响其他接口
模型为官网聊天默认3.5模型

# 相关参数 

model 设置为 chatgpt_hack时生效该bot

## 1.chatgpt_hack_autho（选此bot时填写,失效估测为14天）
获取方法：
f12打开开发者窗口后在聊天界面发送一条消息，出现conversation请求
![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/69687075/10f87c5e-84f4-490f-931b-217353b8cd2a)

## 2. proxy（需海外ip 例127.0.0.1:33210）


# 生态小变动：
1.无法查看 tokens， 返回tokens = invisible
2.在已做过的claude功能基础上实现初始 系统指令 和一般聊天功能，支持上下文&上下文隔离。


# 新增依赖包：
curl_cffi(该包所在路径禁止中文出现)

# 目前已知潜在问题
1.部分环境下会出现chanllenge_required报错，为ip纯净度问题，**更换ip**即可
∞

# 未来优化事项：
1.实现指定对话id
2.尽可能实现openai接口其他配置
3.各类容错提示
∞

## 应用测试

![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/69687075/c3a2979e-6f22-41f9-bf1a-4215995896d1)

## 部署测试

1.环境: 本地vmware ubuntu虚拟机 
2.proxy: 物理机sdkdns转发 openai支持的国家
3.model: chatgpt_hack
4.chatgpt_hack_autho
![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/69687075/1f608fbb-e3c4-45f2-aea8-e110e206e625)



1.环境: 华为云曼谷ubuntu
2.代理: 海外ip
3.model: chatgpt_hack
4.chatgpt_hack_autho
![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/69687075/6bae6e9c-5764-44a0-ac36-874f34cfc8bf)

1.环境: 亚马逊ec2 centos8.2
2.proxy: 海外ip
3.model: chatgpt_hack
4.chatgpt_hack_autho
![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/69687075/788e74e9-1aa3-49f2-aadf-45d27ccbc768)


1.环境: windows10
3.model: chatgpt_hack
4.chatgpt_hack_autho
2.proxy: 本地代理软件端口
![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/69687075/bb2a7f07-dcee-458a-8ae5-98a4f38ccbff)




