### PR TITLE
Update godcmd.py 修复群聊执行管理员命令的逻辑和提示。

### DIFF
--- a/plugins/godcmd/godcmd.py
+++ b/plugins/godcmd/godcmd.py
@@ -235,7 +235,7 @@ class Godcmd(Plugin):
             cmd = command_parts[0]
             args = command_parts[1:]
             isadmin = False
-            if user in self.admin_users:
+            if session_id in self.admin_users:
                 isadmin = True
             ok = False
             result = "string"


### PR DESCRIPTION
itchat下，现有isadmin=true，isgroup=true的逻辑永远没法触发。

![image](https://github.com/zhayujie/chatgpt-on-wechat/assets/31535803/7dec1d2c-e1a8-4755-88cb-b11a35c16481)

管理员认证使用的是私聊receiver=user_id，而群聊里receiver不等于user_id，导致管理员私聊认证后，群聊输入admin命令，无法触发isadmin true。

有时候有些管理指令是希望可以在群里执行的。