### PR TITLE
自定义入群欢迎语和apilot插件

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ available_setting = {
     "group_name_white_list": ["ChatGPT测试群", "ChatGPT测试群2"],  # 开启自动回复的群名称列表
     "group_name_keyword_white_list": [],  # 开启自动回复的群名称关键词列表
     "group_chat_in_one_session": ["ChatGPT测试群"],  # 支持会话上下文共享的群名称
+    "group_welcome_msg": "",  # 配置新人进群固定欢迎语，不配置则使用随机风格欢迎 
     "trigger_by_self": False,  # 是否允许机器人触发
     "image_create_prefix": ["画", "看", "找"],  # 开启图片回复的前缀
     "concurrency_in_session": 1,  # 同一会话最多有多少条消息在处理中，大于1可能乱序

--- a/plugins/hello/hello.py
+++ b/plugins/hello/hello.py
@@ -6,6 +6,7 @@ from bridge.reply import Reply, ReplyType
 from channel.chat_message import ChatMessage
 from common.log import logger
 from plugins import *
+from config import conf
 
 
 @plugins.register(
@@ -31,6 +32,13 @@ class Hello(Plugin):
             return
 
         if e_context["context"].type == ContextType.JOIN_GROUP:
+            if "group_welcome_msg" in conf():
+                reply = Reply()
+                reply.type = ReplyType.TEXT
+                reply.content = conf().get("group_welcome_msg", "")
+                e_context["reply"] = reply
+                e_context.action = EventAction.BREAK_PASS  # 事件结束，并跳过处理context的默认逻辑
+                return
             e_context["context"].type = ContextType.TEXT
             msg: ChatMessage = e_context["context"]["msg"]
             e_context["context"].content = f'请你随机使用一种风格说一句问候语来欢迎新用户"{msg.actual_user_nickname}"加入群聊。'

--- a/plugins/source.json
+++ b/plugins/source.json
@@ -15,6 +15,10 @@
     "timetask": {
       "url": "https://github.com/haikerapples/timetask.git",
       "desc": "一款定时任务系统的插件"
+    },
+    "Apilot": {
+      "url": "https://github.com/6vision/Apilot.git",
+      "desc": "通过api直接查询早报、热榜、快递、天气等实用信息的插件"
     }
   }
 }


### PR DESCRIPTION
1、增加"group_welcome_msg"可选参数，配置微信群聊新人入群自定义欢迎语；
2、增加apilot插件地址，该插件可以快速获取天气、早报、热榜、快递等实用信息。