### PR TITLE
Update chat_gpt_bot.py retry APIConnectionError

### DIFF
--- a/bot/chatgpt/chat_gpt_bot.py
+++ b/bot/chatgpt/chat_gpt_bot.py
@@ -148,8 +148,9 @@ class ChatGPTBot(Bot, OpenAIImage):
                     time.sleep(10)
             elif isinstance(e, openai.error.APIConnectionError):
                 logger.warn("[CHATGPT] APIConnectionError: {}".format(e))
-                need_retry = False
                 result["content"] = "我连接不到你的网络"
+                if need_retry:
+                    time.sleep(5)
             else:
                 logger.exception("[CHATGPT] Exception: {}".format(e))
                 need_retry = False


### PR DESCRIPTION
桐子们，能在这里把retry开一下吗？

OpenAI有时候会断连接，参考 https://community.openai.com/t/api-aborts-my-connection-without-a-reason-anything-i-can-do/104256

导致需要问两边，加上一个retry应该就可以了，时间5秒或者甚至更短一点。

![fe7aefd58c7e7dd2e4d3953603cb8f7](https://github.com/zhayujie/chatgpt-on-wechat/assets/38464985/724a4622-7bff-4efb-83de-3288fb2e7304)
