### PR TITLE
修改调用azure openAI作画地址报错问题

### DIFF
--- a/docker/Dockerfile.latest
+++ b/docker/Dockerfile.latest
@@ -6,19 +6,19 @@ ARG TZ='Asia/Shanghai'
 ARG CHATGPT_ON_WECHAT_VER
 
 RUN echo /etc/apt/sources.list
-# RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list
+RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list
 ENV BUILD_PREFIX=/app
 
 ADD . ${BUILD_PREFIX}
 
 RUN apt-get update \
-    &&apt-get install -y --no-install-recommends bash ffmpeg espeak libavcodec-extra\
+    &&apt-get install -y --no-install-recommends bash ffmpeg espeak libavcodec-extra \
     && cd ${BUILD_PREFIX} \
     && cp config-template.json config.json \
-    && /usr/local/bin/python -m pip install --no-cache --upgrade pip \
-    && pip install --no-cache -r requirements.txt \
-    && pip install --no-cache -r requirements-optional.txt \
-    && pip install azure-cognitiveservices-speech
+    && /usr/local/bin/python -m pip install --no-cache --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip install --no-cache -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip install --no-cache -r requirements-optional.txt -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip install azure-cognitiveservices-speech -i https://pypi.tuna.tsinghua.edu.cn/simple 
 
 WORKDIR ${BUILD_PREFIX}
 


### PR DESCRIPTION
openAI dall-e的url已非url = "{}dalle/text-to-image?api-version={}".format(openai.api_base, api_version)，按照azure DALL-E的示例，直接调用openai.Image对象的create方法，解决原代码使用azure openai画画的报错问题。