### PR TITLE
私聊时增加关键字匹配功能，只在检测到关键字时回复

### DIFF
--- a/channel/chat_channel.py
+++ b/channel/chat_channel.py
@@ -146,6 +146,10 @@ class ChatChannel(Channel):
                     pass
                 else:
                     return None
+
+                if skip_reply(content, conf().get("single_chat_keywords", [])):
+                    return None
+
             content = content.strip()
             img_match_prefix = check_prefix(content, conf().get("image_create_prefix"))
             if img_match_prefix:
@@ -383,6 +387,15 @@ def check_prefix(content, prefix_list):
         if content.startswith(prefix):
             return prefix
     return None
+
+
+def skip_reply(content, keywords):
+    if not keywords:
+        return False
+    for keyword in keywords:
+        if keyword in content:
+            return False
+    return True
 
 
 def check_contain(content, keyword_list):

--- a/config-template.json
+++ b/config-template.json
@@ -11,6 +11,7 @@
     "bot",
     "@bot"
   ],
+  "single_chat_keywords": [],
   "single_chat_reply_prefix": "[bot] ",
   "group_chat_prefix": [
     "@bot"

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ available_setting = {
     "azure_api_version": "",  # azure api版本
     # Bot触发配置
     "single_chat_prefix": ["bot", "@bot"],  # 私聊时文本需要包含该前缀才能触发机器人回复
+    "single_chat_keywords": ["新年"],  # 仅在匹配到关键词时回复，留空则不做关键字筛选
     "single_chat_reply_prefix": "[bot] ",  # 私聊时自动回复的前缀，用于区分真人
     "single_chat_reply_suffix": "",  # 私聊时自动回复的后缀，\n 可以换行
     "group_chat_prefix": ["@bot"],  # 群聊时包含该前缀则会触发机器人回复


### PR DESCRIPTION
动机：比如过年时希望仅自动回复祝福信息，其他信息不需要回复。目前的前缀匹配不足以匹配到所有祝福类信息，看到有pr #902 用正则匹配，好像又太复杂了。

