### PR TITLE
feat: edge-tts 

### DIFF
--- a/config.py
+++ b/config.py
@@ -83,7 +83,7 @@ available_setting = {
     "voice_reply_voice": False,  # 是否使用语音回复语音，需要设置对应语音合成引擎的api key
     "always_reply_voice": False,  # 是否一直使用语音回复
     "voice_to_text": "openai",  # 语音识别引擎，支持openai,baidu,google,azure
-    "text_to_voice": "openai",  # 语音合成引擎，支持openai,baidu,google,pytts(offline),azure,elevenlabs
+    "text_to_voice": "openai",  # 语音合成引擎，支持openai,baidu,google,pytts(offline),azure,elevenlabs,edge(online)
     "text_to_voice_model": "tts-1",
     "tts_voice_id": "alloy",
     # baidu 语音api配置， 使用百度语音识别和语音合成时需要

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -7,6 +7,7 @@ gTTS>=2.3.1 # google text to speech
 pyttsx3>=2.90 # pytsx text to speech
 baidu_aip>=4.16.10 # baidu voice
 azure-cognitiveservices-speech # azure voice
+edge-tts # edge-tts
 numpy<=1.24.2
 langid # language detect
 

--- a/voice/edge/edge_voice.py
+++ b/voice/edge/edge_voice.py
@@ -1,0 +1,50 @@
+import time
+
+import edge_tts
+import asyncio
+
+from bridge.reply import Reply, ReplyType
+from common.log import logger
+from common.tmp_dir import TmpDir
+from voice.voice import Voice
+
+
+class EdgeVoice(Voice):
+
+    def __init__(self):
+        '''
+        # 普通话
+        zh-CN-XiaoxiaoNeural
+        zh-CN-XiaoyiNeural
+        zh-CN-YunjianNeural
+        zh-CN-YunxiNeural
+        zh-CN-YunxiaNeural
+        zh-CN-YunyangNeural
+        # 地方口音
+        zh-CN-liaoning-XiaobeiNeural
+        zh-CN-shaanxi-XiaoniNeural
+        # 粤语
+        zh-HK-HiuGaaiNeural
+        zh-HK-HiuMaanNeural
+        zh-HK-WanLungNeural
+        # 湾湾腔
+        zh-TW-HsiaoChenNeural
+        zh-TW-HsiaoYuNeural
+        zh-TW-YunJheNeural
+        '''
+        self.voice = "zh-CN-YunjianNeural"
+
+    def voiceToText(self, voice_file):
+        pass
+
+    async def gen_voice(self, text, fileName):
+        communicate = edge_tts.Communicate(text, self.voice)
+        await communicate.save(fileName)
+
+    def textToVoice(self, text):
+        fileName = TmpDir().path() + "reply-" + str(int(time.time())) + "-" + str(hash(text) & 0x7FFFFFFF) + ".mp3"
+
+        asyncio.run(self.gen_voice(text, fileName))
+
+        logger.info("[EdgeTTS] textToVoice text={} voice file name={}".format(text, fileName))
+        return Reply(ReplyType.VOICE, fileName)

--- a/voice/factory.py
+++ b/voice/factory.py
@@ -42,4 +42,8 @@ def create_voice(voice_type):
         from voice.ali.ali_voice import AliVoice
 
         return AliVoice()
+    elif voice_type == "edge":
+        from voice.edge.edge_voice import EdgeVoice
+
+        return EdgeVoice()
     raise RuntimeError


### PR DESCRIPTION
Related to this issue https://github.com/zhayujie/chatgpt-on-wechat/issues/1047

A completely free speech synthesis based on reverse engineering of the Edge browser [edge-tts](https://github.com/rany2/edge-tts) (need internet). The effect is exactly the same as Azure in terms of tone and voice, without the need for Azure API. 

You only need to `pip install edge-tts`, and set the `text_to_voice` to `edge`.

The default tune is `zh-CN-YunjianNeural`, native chinese. You can change tone in [`voice\edge\edge_voice.py`](https://github.com/zhayujie/chatgpt-on-wechat/pull/1787/files#diff-41f63f5bcf70be5666114b14da8341d44e9227a94a42811fc37ba5588389cdd0R35). `edge-tts --list-voices` shows all options.