### PR TITLE
由于使用#scanp和#reloadp扫描插件时，当更新已存在的插件以后并不会实现重载更新后的插件

### DIFF
--- a/plugins/plugin_manager.py
+++ b/plugins/plugin_manager.py
@@ -99,7 +99,7 @@ class PluginManager:
                     try:
                         self.current_plugin_path = plugin_path
                         if plugin_path in self.loaded:
-                            if self.loaded[plugin_path] == None:
+                            if plugin_name.upper() != 'GODCMD':
                                 logger.info("reload module %s" % plugin_name)
                                 self.loaded[plugin_path] = importlib.reload(sys.modules[import_path])
                                 dependent_module_names = [name for name in sys.modules.keys() if name.startswith(import_path + ".")]
@@ -141,7 +141,7 @@ class PluginManager:
         failed_plugins = []
         for name, plugincls in self.plugins.items():
             if plugincls.enabled:
-                if name not in self.instances:
+                # if name not in self.instances:
                     try:
                         instance = plugincls()
                     except Exception as e:

--- a/plugins/plugin_manager.py
+++ b/plugins/plugin_manager.py
@@ -141,19 +141,21 @@ class PluginManager:
         failed_plugins = []
         for name, plugincls in self.plugins.items():
             if plugincls.enabled:
+                if 'GODCMD' in self.instances and name == 'GODCMD':
+                    continue
                 # if name not in self.instances:
-                    try:
-                        instance = plugincls()
-                    except Exception as e:
-                        logger.warn("Failed to init %s, diabled. %s" % (name, e))
-                        self.disable_plugin(name)
-                        failed_plugins.append(name)
-                        continue
-                    self.instances[name] = instance
-                    for event in instance.handlers:
-                        if event not in self.listening_plugins:
-                            self.listening_plugins[event] = []
-                        self.listening_plugins[event].append(name)
+                try:
+                    instance = plugincls()
+                except Exception as e:
+                    logger.warn("Failed to init %s, diabled. %s" % (name, e))
+                    self.disable_plugin(name)
+                    failed_plugins.append(name)
+                    continue
+                self.instances[name] = instance
+                for event in instance.handlers:
+                    if event not in self.listening_plugins:
+                        self.listening_plugins[event] = []
+                    self.listening_plugins[event].append(name)
         self.refresh_order()
         return failed_plugins
 


### PR DESCRIPTION
取消了已载入的插件判断，重载除Godcmd以外的所有插件来实现不需要重启项目即可更新插件