### PR TITLE
fix ReplyType.IMAGE 回复图片为空的BUG

### DIFF
--- a/channel/wechat/wechat_channel.py
+++ b/channel/wechat/wechat_channel.py
@@ -233,6 +233,7 @@ class WechatChannel(ChatChannel):
             logger.info("[WX] sendImage url={}, receiver={}".format(img_url, receiver))
         elif reply.type == ReplyType.IMAGE:  # 从文件读取图片
             image_storage = reply.content
+            image_storage.seek(0)
             itchat.send_image(image_storage, toUserName=receiver)
             logger.info("[WX] sendImage, receiver={}".format(receiver))
         elif reply.type == ReplyType.FILE:  # 新增文件回复类型


### PR DESCRIPTION
使用replytype = IMAGE时候，无法正常发送图片，但是日志没有报错

加上这段代码，可以正常发送图片