### PR TITLE
fix openai voice_to_text whisper

### DIFF
--- a/voice/openai/openai_voice.py
+++ b/voice/openai/openai_voice.py
@@ -21,8 +21,21 @@ class OpenaiVoice(Voice):
         logger.debug("[Openai] voice file name={}".format(voice_file))
         try:
             file = open(voice_file, "rb")
-            result = openai.Audio.transcribe("whisper-1", file)
-            text = result["text"]
+            api_base = conf().get("open_ai_api_base") or "https://api.openai.com/v1"
+            url = f'{api_base}/audio/transcriptions'
+            headers = {
+                'Authorization': 'Bearer ' + conf().get("open_ai_api_key"),
+                # 'Content-Type': 'multipart/form-data' # 加了会报错，不知道什么原因
+            }
+            files = {
+                "file": file,
+            }
+            data = {
+                "model": "whisper-1",
+            }
+            response = requests.post(url, headers=headers, files=files, data=data)
+            response_data = response.json()
+            text = response_data['text']
             reply = Reply(ReplyType.TEXT, text)
             logger.info("[Openai] voiceToText text={} voice file name={}".format(text, voice_file))
         except Exception as e:


### PR DESCRIPTION
解决openai语音识别问题，作者用的是`openai==0.27.8`，好多调用方法都可能弃用了，包括
https://github.com/zhayujie/chatgpt-on-wechat/blob/31ac80a07479dfc85f51d5a20087a492003d7aea/voice/openai/openai_voice.py#L24

故改为比较原始的用`requests`发请求，作者可以考虑一下升级`openai-python`的版本，现在最新的已经到`openai==1.17.1`了。

目前的修改仅仅是为了能用，不是一个完美的解决方案。

解决：
https://github.com/zhayujie/chatgpt-on-wechat/issues/1717
https://github.com/zhayujie/chatgpt-on-wechat/issues/1666
https://github.com/zhayujie/chatgpt-on-wechat/issues/1638
https://github.com/zhayujie/chatgpt-on-wechat/issues/1618
https://github.com/zhayujie/chatgpt-on-wechat/issues/1540