### PR TITLE
Update godcmd.py for the question that admin userId added two times 

### DIFF
--- a/plugins/godcmd/godcmd.py
+++ b/plugins/godcmd/godcmd.py
@@ -452,11 +452,11 @@ class Godcmd(Plugin):
         password = args[0]
         if password == self.password:
             self.admin_users.append(userid)
-            global_config["admin_users"].append(userid)
+            # global_config["admin_users"].append(userid)
             return True, "认证成功"
         elif password == self.temp_password:
             self.admin_users.append(userid)
-            global_config["admin_users"].append(userid)
+            # global_config["admin_users"].append(userid)
             return True, "认证成功，请尽快设置口令"
         else:
             return False, "认证失败"


### PR DESCRIPTION
I'm not sure if it's intentional, but I found that the godcmd plugin adds the userId twice to the global configuration during authentication in the process of developing the plugin. The ids retrieved during plugin authentication are duplicated twice, and I personally think this situation is unnecessary. If there's a special purpose for this, pl
[Click here to my Issue](https://github.com/zhayujie/chatgpt-on-wechat/issues/1895)