### PR TITLE
新增url解析逻辑，解决itchat中分享卡片无法解析的问题

### DIFF
--- a/plugins/linkai/summary.py
+++ b/plugins/linkai/summary.py
@@ -2,6 +2,7 @@ import requests
 from config import conf
 from common.log import logger
 import os
+import html
 
 
 class LinkSummary:
@@ -18,6 +19,7 @@ class LinkSummary:
         return self._parse_summary_res(res)
 
     def summary_url(self, url: str):
+        url = html.unescape(url)
         body = {
             "url": url
         }


### PR DESCRIPTION
微信变更了网页版的链接规则，需要通过解析把`&amp;`转换成`&`，不然itchat的机器人就会无法解析，官方的机器人已经失效了，可能大佬没关注到

![CleanShot 2024-04-20 at 00 55 38@2x](https://github.com/zhayujie/chatgpt-on-wechat/assets/134143178/2ea26d8f-75e0-4846-bf07-4940a22a6241)
