### PR TITLE
问题修复

### DIFF
--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -1,3 +1,7 @@
+import sys
+
+sys.path.append('../')
+
 from bot.bot_factory import create_bot
 from bridge.context import Context
 from bridge.reply import Reply


### PR DESCRIPTION
修复Windows Server系统下，项目启动找不到（translate.factory）模块的问题。

版本：1.6.0

前置原因：在win10系统下可以正常启动，迁移到Windows Server系统后，启动报错：ModuleNotFoundError: No module named 'translate.factory'。

详细堆栈信息：
Traceback (most recent call last):
  File "app.py", line 8, in <module>
    from channel import channel_factory
  File "D:\chatgpt-on-wechat\channel\channel_factory.py", line 5, in <module>
    from .channel import Channel
  File "D:\chatgpt-on-wechat\channel\channel.py", line 5, in <module>
    from bridge.bridge import Bridge
  File "D:\chatgpt-on-wechat\bridge\bridge.py", line 11, in <module>
    from translate.factory import create_translator
ModuleNotFoundError: No module named 'translate.factory'

已确认依赖均已下载的情况下，根据错误提示，排查代码找到原因：bridge文件导入的translate.factory模块在文件的上一级目录下，所以在同级目录下找不到此类文件。

解决方案已应用：在目标文件内添加上一级搜索路径。