### PR TITLE
Fix TypeError in config drag_sensitive function

### DIFF
--- a/config.py
+++ b/config.py
@@ -242,7 +242,7 @@ def drag_sensitive(config):
             conf_dict_copy = copy.deepcopy(conf_dict)
             for key in conf_dict_copy:
                 if "key" in key or "secret" in key:
-                    if isinstance(key, str):
+                    if isinstance(conf_dict_copy[key], str):
                         conf_dict_copy[key] = conf_dict_copy[key][0:3] + "*" * 5 + conf_dict_copy[key][-3:]
             return json.dumps(conf_dict_copy, indent=4)
 
@@ -250,7 +250,7 @@ def drag_sensitive(config):
             config_copy = copy.deepcopy(config)
             for key in config:
                 if "key" in key or "secret" in key:
-                    if isinstance(key, str):
+                    if isinstance(config_copy[key], str):
                         config_copy[key] = config_copy[key][0:3] + "*" * 5 + config_copy[key][-3:]
             return config_copy
     except Exception as e:


### PR DESCRIPTION
解决了drag_sensitive函数中因尝试将列表项字符串进行连接而导致的TypeError问题。详见 #2094 和 #2096