### PR TITLE
fix：在docker-compose.yml文件中增加时区设置

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     security_opt:
       - seccomp:unconfined
     environment:
+      TZ: 'Asia/Shanghai'
       OPEN_AI_API_KEY: 'YOUR API KEY'
       MODEL: 'gpt-3.5-turbo'
       PROXY: ''


### PR DESCRIPTION
由于 docker 容器默认时区为0时区，在时间方面就会与东8区时间不一致。比如在使用 timetask 插件配置定时任务时，时间就会慢8小时。