### PR TITLE
Default close tool plugin.

### DIFF
--- a/plugins/tool/tool.py
+++ b/plugins/tool/tool.py
@@ -21,11 +21,15 @@ from plugins import *
 class Tool(Plugin):
     def __init__(self):
         super().__init__()
-        self.handlers[Event.ON_HANDLE_CONTEXT] = self.on_handle_context
-
-        self.app = self._reset_app()
-
-        logger.info("[tool] inited")
+        try:
+            self.handlers[Event.ON_HANDLE_CONTEXT] = self.on_handle_context
+            self.app = self._reset_app()
+            if not self.tool_config.get("tools"):
+                raise Exception("config.json not found")
+            logger.info("[tool] inited")
+        except Exception as e:
+            logger.warn("[tool] init failed, ignore ")
+            raise e
 
     def get_help_text(self, verbose=False, **kwargs):
         help_text = "这是一个能让chatgpt联网，搜索，数字运算的插件，将赋予强大且丰富的扩展能力。"


### PR DESCRIPTION
因tool插件的部分工具有一定风险，若tool插件下没有主动生成有效的配置文件`config.json`，则默认关闭该插件。
手动从模板文件生成后有效配置文件后，可到plugins/plugins.json文件手动开启tool插件，然后重新运行项目即可使用tool插件。