### PR TITLE
Cancel subscribe_msg of wechatcomapp channel

### DIFF
--- a/channel/wechatcom/wechatcomapp_channel.py
+++ b/channel/wechatcom/wechatcomapp_channel.py
@@ -162,11 +162,12 @@ class Query:
         logger.debug("[wechatcom] receive message: {}, msg= {}".format(message, msg))
         if msg.type == "event":
             if msg.event == "subscribe":
-                reply_content = subscribe_msg()
-                if reply_content:
-                    reply = create_reply(reply_content, msg).render()
-                    res = channel.crypto.encrypt_message(reply, nonce, timestamp)
-                    return res
+                pass
+                # reply_content = subscribe_msg()
+                # if reply_content:
+                #     reply = create_reply(reply_content, msg).render()
+                #     res = channel.crypto.encrypt_message(reply, nonce, timestamp)
+                #     return res
         else:
             try:
                 wechatcom_msg = WechatComAppMessage(msg, client=channel.client)


### PR DESCRIPTION
企微自建应用，取消管理员添加成员到应用可见范围时自动发送订阅消息的功能，避免变动权限时给成员造成干扰。
如需给成员批量发送信息，可以进入[企微后台](https://work.weixin.qq.com/wework_admin/frame#/apps)，进入应用，使用应用的”**发送消息**“功能