### PR TITLE
fix: "model":"mooshoot", which defaults to "moonshot-v1-32k".

### DIFF
--- a/bot/moonshot/moonshot_bot.py
+++ b/bot/moonshot/moonshot_bot.py
@@ -19,8 +19,11 @@ class MoonshotBot(Bot):
     def __init__(self):
         super().__init__()
         self.sessions = SessionManager(MoonshotSession, model=conf().get("model") or "moonshot-v1-128k")
+        model = conf().get("model") or "moonshot-v1-128k"
+        if model == "moonshot":
+            model = "moonshot-v1-32k"
         self.args = {
-            "model": conf().get("model") or "moonshot-v1-128k",  # 对话模型的名称
+            "model": model,  # 对话模型的名称
             "temperature": conf().get("temperature", 0.3),  # 如果设置，值域须为 [0, 1] 我们推荐 0.3，以达到较合适的效果。
             "top_p": conf().get("top_p", 1.0),  # 使用默认值
         }

--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -46,7 +46,7 @@ class Bridge(object):
             if model_type in ["claude"]:
                 self.btype["chat"] = const.CLAUDEAI
 
-            if model_type in ["moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"]:
+            if model_type in [const.MOONSHOT, "moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k"]:
                 self.btype["chat"] = const.MOONSHOT
 
             if model_type in ["abab6.5-chat"]:


### PR DESCRIPTION
修复`"model": "moonshot"`时，无法路由到对应的bot，并默认指向`"moonshot-v1-32k"`模型