### PR TITLE
Handle ASCII QR code print error on Windows

### DIFF
--- a/channel/wechat/wechat_channel.py
+++ b/channel/wechat/wechat_channel.py
@@ -10,7 +10,6 @@ import os
 import threading
 import time
 import requests
-import sys
 
 from bridge.context import *
 from bridge.reply import *


### PR DESCRIPTION
Add try-except block to handle UnicodeEncodeError during ASCII QR code printing on Windows   #2296