### PR TITLE
fix：工具调用（例如FastGPT等）时返回reply.content为数组时报错的问题

### DIFF
--- a/channel/chat_channel.py
+++ b/channel/chat_channel.py
@@ -250,6 +250,9 @@ class ChatChannel(Channel):
 
                 if reply.type == ReplyType.TEXT:
                     reply_text = reply.content
+                     # 处理工具调用时 reply_text 为 list 的情况
+                    if type(reply_text) is list:
+                        reply_text = "\n".join(item.text.content for item in reply_text if item.type == "text")
                     if desire_rtype == ReplyType.VOICE and ReplyType.VOICE not in self.NOT_SUPPORT_REPLYTYPE:
                         reply = super().build_text_to_voice(reply.content)
                         return self._decorate_reply(context, reply)


### PR DESCRIPTION
当调用FastGPT等OpenAI兼容接口进行工具调用时，返回的reply.content为数组，造成can only concatenate str (not "list") to str报错。

增加了判断逻辑，检测到数组时，先将其合并为string。

相关issues：
https://github.com/zhayujie/chatgpt-on-wechat/issues/2111
https://github.com/zhayujie/chatgpt-on-wechat/issues/2131
https://github.com/zhayujie/chatgpt-on-wechat/issues/2137
https://github.com/zhayujie/chatgpt-on-wechat/issues/2274
https://github.com/zhayujie/chatgpt-on-wechat/issues/2275