### PR TITLE
Claude model update

### DIFF
--- a/bot/claudeapi/claude_api_bot.py
+++ b/bot/claudeapi/claude_api_bot.py
@@ -8,8 +8,7 @@ import anthropic
 
 from bot.bot import Bot
 from bot.openai.open_ai_image import OpenAIImage
-from bot.chatgpt.chat_gpt_session import ChatGPTSession
-from bot.gemini.google_gemini_bot import GoogleGeminiBot
+from bot.baidu.baidu_wenxin_session import BaiduWenxinSession
 from bot.session_manager import SessionManager
 from bridge.context import ContextType
 from bridge.reply import Reply, ReplyType
@@ -34,7 +33,7 @@ class ClaudeAPIBot(Bot, OpenAIImage):
         if proxy:
             openai.proxy = proxy
 
-        self.sessions = SessionManager(ChatGPTSession, model=conf().get("model") or "text-davinci-003")
+        self.sessions = SessionManager(BaiduWenxinSession, model=conf().get("model") or "text-davinci-003")
 
     def reply(self, query, context=None):
         # acquire reply content
@@ -77,14 +76,14 @@ class ClaudeAPIBot(Bot, OpenAIImage):
                     reply = Reply(ReplyType.ERROR, retstring)
                 return reply
 
-    def reply_text(self, session: ChatGPTSession, retry_count=0):
+    def reply_text(self, session: BaiduWenxinSession, retry_count=0):
         try:
             actual_model = self._model_mapping(conf().get("model"))
             response = self.claudeClient.messages.create(
                 model=actual_model,
-                max_tokens=1024,
-                # system=conf().get("system"),
-                messages=GoogleGeminiBot.filter_messages(session.messages)
+                max_tokens=4096,
+                system=conf().get("character_desc", ""),
+                messages=session.messages
             )
             # response = openai.Completion.create(prompt=str(session), **self.args)
             res_content = response.content[0].text.strip().replace("<|endoftext|>", "")

--- a/bot/claudeapi/claude_api_bot.py
+++ b/bot/claudeapi/claude_api_bot.py
@@ -23,16 +23,13 @@ user_session = dict()
 class ClaudeAPIBot(Bot, OpenAIImage):
     def __init__(self):
         super().__init__()
+        proxy = conf().get("proxy", None)
+        base_url = conf().get("open_ai_api_base", None)  # 复用"open_ai_api_base"参数作为base_url
         self.claudeClient = anthropic.Anthropic(
-            api_key=conf().get("claude_api_key")
+            api_key=conf().get("claude_api_key"),
+            proxies=proxy if proxy else None,
+            base_url=base_url if base_url else None
         )
-        openai.api_key = conf().get("open_ai_api_key")
-        if conf().get("open_ai_api_base"):
-            openai.api_base = conf().get("open_ai_api_base")
-        proxy = conf().get("proxy")
-        if proxy:
-            openai.proxy = proxy
-
         self.sessions = SessionManager(BaiduWenxinSession, model=conf().get("model") or "text-davinci-003")
 
     def reply(self, query, context=None):

--- a/bot/claudeapi/claude_api_bot.py
+++ b/bot/claudeapi/claude_api_bot.py
@@ -97,7 +97,7 @@ class ClaudeAPIBot(Bot, OpenAIImage):
             }
         except Exception as e:
             need_retry = retry_count < 2
-            result = {"completion_tokens": 0, "content": "我现在有点累了，等会再来吧"}
+            result = {"total_tokens": 0, "completion_tokens": 0, "content": "我现在有点累了，等会再来吧"}
             if isinstance(e, openai.error.RateLimitError):
                 logger.warn("[CLAUDE_API] RateLimitError: {}".format(e))
                 result["content"] = "提问太快啦，请休息一下再问我吧"

--- a/bot/claudeapi/claude_api_bot.py
+++ b/bot/claudeapi/claude_api_bot.py
@@ -14,6 +14,7 @@ from bot.session_manager import SessionManager
 from bridge.context import ContextType
 from bridge.reply import Reply, ReplyType
 from common.log import logger
+from common import const
 from config import conf
 
 user_session = dict()
@@ -125,11 +126,11 @@ class ClaudeAPIBot(Bot, OpenAIImage):
 
     def _model_mapping(self, model) -> str:
         if model == "claude-3-opus":
-            return "claude-3-opus-20240229"
+            return const.CLAUDE_3_OPUS
         elif model == "claude-3-sonnet":
-            return "claude-3-sonnet-20240229"
+            return const.CLAUDE_3_SONNET
         elif model == "claude-3-haiku":
-            return "claude-3-haiku-20240307"
+            return const.CLAUDE_3_HAIKU
         elif model == "claude-3.5-sonnet":
-            return "claude-3-5-sonnet-20240620"
+            return const.CLAUDE_35_SONNET
         return model

--- a/channel/wechat/wechat_message.py
+++ b/channel/wechat/wechat_message.py
@@ -55,6 +55,16 @@ class WechatMessage(ChatMessage):
                     self.ctype = ContextType.EXIT_GROUP
                     self.content = itchat_msg["Content"]
                     self.actual_user_nickname = re.findall(r"\"(.*?)\"", itchat_msg["Content"])[0]
+
+                elif any(note_patpat in itchat_msg["Content"] for note_patpat in notes_patpat):  # 若有任何在notes_patpat列表中的字符串出现在NOTE中:
+                    self.ctype = ContextType.PATPAT
+                    self.content = itchat_msg["Content"]
+                    if "拍了拍我" in itchat_msg["Content"]:  # 识别中文
+                        self.actual_user_nickname = re.findall(r"\"(.*?)\"", itchat_msg["Content"])[0]
+                    elif "tickled my" in itchat_msg["Content"] or "tickled me" in itchat_msg["Content"]:
+                        self.actual_user_nickname = re.findall(r'^(.*?)(?:tickled my|tickled me)', itchat_msg["Content"])[0]
+                else:
+                    raise NotImplementedError("Unsupported note message: " + itchat_msg["Content"])
                     
             elif "你已添加了" in itchat_msg["Content"]:  #通过好友请求
                 self.ctype = ContextType.ACCEPT_FRIEND
@@ -62,11 +72,6 @@ class WechatMessage(ChatMessage):
             elif any(note_patpat in itchat_msg["Content"] for note_patpat in notes_patpat):  # 若有任何在notes_patpat列表中的字符串出现在NOTE中:
                 self.ctype = ContextType.PATPAT
                 self.content = itchat_msg["Content"]
-                if is_group:
-                    if "拍了拍我" in itchat_msg["Content"]:  # 识别中文
-                        self.actual_user_nickname = re.findall(r"\"(.*?)\"", itchat_msg["Content"])[0]
-                    elif ("tickled my" in itchat_msg["Content"] or "tickled me" in itchat_msg["Content"]):
-                        self.actual_user_nickname = re.findall(r'^(.*?)(?:tickled my|tickled me)', itchat_msg["Content"])[0]
             else:
                 raise NotImplementedError("Unsupported note message: " + itchat_msg["Content"])
         elif itchat_msg["Type"] == ATTACHMENT:

--- a/common/const.py
+++ b/common/const.py
@@ -69,6 +69,17 @@ GLM_4_0520 = "glm-4-0520"
 GLM_4_AIR = "glm-4-air"
 GLM_4_AIRX = "glm-4-airx"
 
+
+CLAUDE_3_OPUS = "claude-3-opus-latest"
+CLAUDE_3_OPUS_0229 = "claude-3-opus-20240229"
+
+CLAUDE_35_SONNET = "claude-3-5-sonnet-latest"  # 带 latest 标签的模型名称，会不断更新指向最新发布的模型
+CLAUDE_35_SONNET_1022 = "claude-3-5-sonnet-20241022"  # 带具体日期的模型名称，会固定为该日期发布的模型
+CLAUDE_35_SONNET_0620 = "claude-3-5-sonnet-20240620"
+CLAUDE_3_SONNET = "claude-3-sonnet-20240229"
+
+CLAUDE_3_HAIKU = "claude-3-haiku-20240307"
+
 MODEL_LIST = [
               GPT35, GPT35_0125, GPT35_1106, "gpt-3.5-turbo-16k",
               O1, O1_MINI, GPT_4o, GPT_4O_0806, GPT_4o_MINI, GPT4_TURBO, GPT4_TURBO_PREVIEW, GPT4_TURBO_01_25, GPT4_TURBO_11_06, GPT4, GPT4_32k, GPT4_06_13, GPT4_32k_06_13,
@@ -77,7 +88,7 @@ MODEL_LIST = [
               ZHIPU_AI, GLM_4, GLM_4_PLUS, GLM_4_flash, GLM_4_LONG, GLM_4_ALLTOOLS, GLM_4_0520, GLM_4_AIR, GLM_4_AIRX,
               MOONSHOT, MiniMax,
               GEMINI, GEMINI_PRO, GEMINI_15_flash, GEMINI_15_PRO,
-              "claude", "claude-3-haiku", "claude-3-sonnet", "claude-3-opus", "claude-3-opus-20240229", "claude-3.5-sonnet",
+              CLAUDE_3_OPUS, CLAUDE_3_OPUS_0229, CLAUDE_35_SONNET, CLAUDE_35_SONNET_1022, CLAUDE_35_SONNET_0620, CLAUDE_3_SONNET, CLAUDE_3_HAIKU, "claude", "claude-3-haiku", "claude-3-sonnet", "claude-3-opus", "claude-3.5-sonnet",
               "moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k",
               QWEN, QWEN_TURBO, QWEN_PLUS, QWEN_MAX,
               LINKAI_35, LINKAI_4_TURBO, LINKAI_4o

--- a/common/utils.py
+++ b/common/utils.py
@@ -70,6 +70,7 @@ def convert_webp_to_png(webp_image):
         logger.error(f"Failed to convert WEBP to PNG: {e}")
         raise
 
+
 def remove_markdown_symbol(text: str):
     # 移除markdown格式，目前先移除**
     if not text:

--- a/plugins/godcmd/godcmd.py
+++ b/plugins/godcmd/godcmd.py
@@ -313,7 +313,7 @@ class Godcmd(Plugin):
                     except Exception as e:
                         ok, result = False, "你没有设置私有GPT模型"
                 elif cmd == "reset":
-                    if bottype in [const.OPEN_AI, const.CHATGPT, const.CHATGPTONAZURE, const.LINKAI, const.BAIDU, const.XUNFEI, const.QWEN, const.GEMINI, const.ZHIPU_AI]:
+                    if bottype in [const.OPEN_AI, const.CHATGPT, const.CHATGPTONAZURE, const.LINKAI, const.BAIDU, const.XUNFEI, const.QWEN, const.GEMINI, const.ZHIPU_AI, const.CLAUDEAPI]:
                         bot.sessions.clear_session(session_id)
                         if Bridge().chat_bots.get(bottype):
                             Bridge().chat_bots.get(bottype).sessions.clear_session(session_id)


### PR DESCRIPTION
1、支持claude新模型`claude-3-5-sonnet-20241022`。使用该新模型，`model`填以下其一即可：
```
"claude-3.5-sonnet"、"claude-3-5-sonnet-latest"、"claude-3-5-sonnet-20241022"
```
推荐使用`"claude-3-5-sonnet-latest"`，该模型名会不断指向最新发布的对应模型。
2、claude模型支持设置`proxy`和`basel_url`:
   - `"proxy": "http://127.0.0.1:10809"`
   - `"base_url": "https://api.link-ai.tech/"`，复用"open_ai_api_base"参数。注意：使用此参数，需要服务商支持，目前大多不直接以claude格式的提供代理服务
   
3、优化访问失败，报错`key error`的问题
4、优化对话管理，并支持了系统提示词，在根目录配置文件修改`"character_desc"`参数即可
5、支持了`#reset`会话重置指令
相关issues: #2351 