### PR TITLE
Summary and MJ  support can be configured through LinkAI platform app plugins

### DIFF
--- a/plugins/linkai/README.md
+++ b/plugins/linkai/README.md
@@ -98,6 +98,8 @@
 
 如果不想创建 `plugins/linkai/config.json` 配置，可以直接通过 `$linkai sum open` 指令开启该功能。
 
+也可以通过私聊(全局 `config.json` 中的 `linkai_app_code`)或者群聊绑定(通过`group_app_map`参数配置)的应用来开启该功能：在LinkAI平台 [应用配置](https://link-ai.tech/console/factory) 里添加并开启**内容总结**插件。
+
 #### 使用
 
 功能开启后，向机器人发送 **文件**、 **分享链接卡片**、**图片** 即可生成摘要，进一步可以与文件或链接的内容进行多轮对话。如果需要关闭某种类型的内容总结，设置 `summary`配置中的type字段即可。

--- a/plugins/linkai/summary.py
+++ b/plugins/linkai/summary.py
@@ -9,19 +9,21 @@ class LinkSummary:
     def __init__(self):
         pass
 
-    def summary_file(self, file_path: str):
+    def summary_file(self, file_path: str, app_code: str):
         file_body = {
             "file": open(file_path, "rb"),
             "name": file_path.split("/")[-1],
+            "app_code": app_code
         }
         url = self.base_url() + "/v1/summary/file"
         res = requests.post(url, headers=self.headers(), files=file_body, timeout=(5, 300))
         return self._parse_summary_res(res)
 
-    def summary_url(self, url: str):
+    def summary_url(self, url: str, app_code: str):
         url = html.unescape(url)
         body = {
-            "url": url
+            "url": url,
+            "app_code": app_code
         }
         res = requests.post(url=self.base_url() + "/v1/summary/url", headers=self.headers(), json=body, timeout=(5, 180))
         return self._parse_summary_res(res)

--- a/plugins/linkai/utils.py
+++ b/plugins/linkai/utils.py
@@ -1,7 +1,9 @@
+import requests
+from common.log import logger
 from config import global_config
 from bridge.reply import Reply, ReplyType
 from plugins.event import EventContext, EventAction
-
+from config import conf
 
 class Util:
     @staticmethod
@@ -26,3 +28,20 @@ class Util:
         reply = Reply(level, content)
         e_context["reply"] = reply
         e_context.action = EventAction.BREAK_PASS
+
+    @staticmethod
+    def fetch_app_plugin(app_code: str, plugin_name: str) -> bool:
+        headers = {"Authorization": "Bearer " + conf().get("linkai_api_key")}
+        # do http request
+        base_url = conf().get("linkai_api_base", "https://api.link-ai.tech")
+        params = {"app_code": app_code}
+        res = requests.get(url=base_url + "/v1/app/info", params=params, headers=headers, timeout=(5, 10))
+        if res.status_code == 200:
+            plugins = res.json().get("data").get("plugins")
+            for plugin in plugins:
+                if plugin.get("name") and plugin.get("name") == plugin_name:
+                    return True
+            return False
+        else:
+            logger.warning(f"[LinkAI] find app info exception, res={res}")
+            return False


### PR DESCRIPTION
支持`/plugins/linkai`插件除了[本地配置或者指令开启](https://github.com/zhayujie/chatgpt-on-wechat/blob/master/plugins/linkai/README.md)以外，还可以通过在linkai平台通过[应用的插件配置](https://link-ai.tech/console/factory)来开启(关闭):
- 私聊：可以通过根目录参数`linkai_app_code`配置应用，在LinkAI平台找到该应用，添加并开启(关闭)MJ插件/内容总结插件
- 群聊：需要先通过`/plugins/linkai/config.json`里的`group_app_map`参数配置群聊对应的应用，或者通过指令`$linkai app <app_code>`来给群聊绑定应用，然后在LinkAI平台找到该应用，添加并开启MJ/内容总结插件。

注：
1、如果只想部分群聊开启mj/总结功能，可以把`/plugins/linkai/config.json`文件里`"summary"`相关的配置关闭，在LinkAI平台，把这些群聊对应应用的mj/总结插件打开即可
2、后续很快兼容LinkAI平台应用**内容总结**插件的自定义提示词功能