### PR TITLE
添加ports映射让企业微信channel正常运行

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,3 +23,5 @@ services:
       USE_LINKAI: 'False'
       LINKAI_API_KEY: ''
       LINKAI_APP_CODE: ''
+    ports:    
+      - "9898:9898"


### PR DESCRIPTION
原docker方式运行选用企微通道 wechatcom_app 时 并不会监听9898端口，导致无法使用。

如不添加到yml文件中，建议修改相应的说明文档