### PR TITLE
add gitee-ai model resources that are compatible with openai format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 最新版本支持的功能如下：
 
 -  ✅   **多端部署：** 有多种部署方式可选择且功能完备，目前已支持微信公众号、企业微信应用、飞书、钉钉等部署方式
--  ✅   **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3.5, GPT-4o-mini, GPT-4o,  GPT-4, Claude-3.5, Gemini, 文心一言, 讯飞星火, 通义千问，ChatGLM-4，Kimi(月之暗面), MiniMax
+-  ✅   **基础对话：** 私聊及群聊的消息智能回复，支持多轮会话上下文记忆，支持 GPT-3.5, GPT-4o-mini, GPT-4o,  GPT-4, Claude-3.5, Gemini, 文心一言, 讯飞星火, 通义千问，ChatGLM-4，Kimi(月之暗面), MiniMax, GiteeAI
 -  ✅   **语音能力：** 可识别语音消息，通过文字或语音回复，支持 azure, baidu, google, openai(whisper/tts) 等多种语音模型
 -  ✅   **图像能力：** 支持图片生成、图片识别、图生图（如照片修复），可选择 Dall-E-3, stable diffusion, replicate, midjourney, CogView-3, vision模型
 -  ✅   **丰富插件：** 支持个性化插件扩展，已实现多角色切换、文字冒险、敏感词过滤、聊天记录总结、文档总结和对话、联网搜索等插件

--- a/bot/chatgpt/chat_gpt_session.py
+++ b/bot/chatgpt/chat_gpt_session.py
@@ -83,7 +83,7 @@ def num_tokens_from_messages(messages, model):
         tokens_per_message = 3
         tokens_per_name = 1
     else:
-        logger.warn(f"num_tokens_from_messages() is not implemented for model {model}. Returning num tokens assuming gpt-3.5-turbo.")
+        logger.debug(f"num_tokens_from_messages() is not implemented for model {model}. Returning num tokens assuming gpt-3.5-turbo.")
         return num_tokens_from_messages(messages, model="gpt-3.5-turbo")
     num_tokens = 0
     for message in messages:

--- a/common/const.py
+++ b/common/const.py
@@ -82,6 +82,8 @@ CLAUDE_3_SONNET = "claude-3-sonnet-20240229"
 
 CLAUDE_3_HAIKU = "claude-3-haiku-20240307"
 
+GITEE_AI_MODEL_LIST = ["Yi-34B-Chat", "InternVL2-8B", "deepseek-coder-33B-instruct", "InternVL2.5-26B", "Qwen2-VL-72B", "Qwen2.5-32B-Instruct", "glm-4-9b-chat", "codegeex4-all-9b", "Qwen2.5-Coder-32B-Instruct", "Qwen2.5-72B-Instruct", "Qwen2.5-7B-Instruct", "Qwen2-72B-Instruct", "Qwen2-7B-Instruct", "code-raccoon-v1", "Qwen2.5-14B-Instruct"]
+
 MODEL_LIST = [
               GPT35, GPT35_0125, GPT35_1106, "gpt-3.5-turbo-16k",
               O1, O1_MINI, GPT_4o, GPT_4O_0806, GPT_4o_MINI, GPT4_TURBO, GPT4_TURBO_PREVIEW, GPT4_TURBO_01_25, GPT4_TURBO_11_06, GPT4, GPT4_32k, GPT4_06_13, GPT4_32k_06_13,
@@ -96,6 +98,7 @@ MODEL_LIST = [
               LINKAI_35, LINKAI_4_TURBO, LINKAI_4o
             ]
 
+MODEL_LIST = MODEL_LIST + GITEE_AI_MODEL_LIST
 # channel
 FEISHU = "feishu"
 DINGTALK = "dingtalk"


### PR DESCRIPTION
新增Gitee AI模型资源，兼容openai格式，目前支持的对话模型列表：
```
["Yi-34B-Chat", "InternVL2-8B", "deepseek-coder-33B-instruct", "InternVL2.5-26B", "Qwen2-VL-72B", "Qwen2.5-32B-Instruct", "glm-4-9b-chat", "codegeex4-all-9b", "Qwen2.5-Coder-32B-Instruct", "Qwen2.5-72B-Instruct", "Qwen2.5-7B-Instruct", "Qwen2-72B-Instruct", "Qwen2-7B-Instruct", "code-raccoon-v1", "Qwen2.5-14B-Instruct"]
```

更多模型见：[serverless-api](https://ai.gitee.com/serverless-api#)

API_KEY获取：在 Gitee AI 工作台 - 设置 - 访问令牌，复制访问令牌（API key）

配置文件修改：
```
"bot_type": "chatGPT",
"model": "Qwen2.5-72B-Instruct",
"open_ai_api_key": "K8CJTFxxxxxxxxxxxxxxxxxxxxxxxxxx7IBTQEJFA5Z"
"open_ai_api_base": "https://ai.gitee.com/v1",
```
同时支持在对话中通过`#model`指令修改模型：`#model Qwen2.5-32B-Instruct`