### PR TITLE
fix: resolve display issue for replies containing only image URLs

### DIFF
--- a/bot/linkai/link_ai_bot.py
+++ b/bot/linkai/link_ai_bot.py
@@ -147,9 +147,9 @@ class LinkAIBot(Bot):
                 if response["choices"][0].get("img_urls"):
                     thread = threading.Thread(target=self._send_image, args=(context.get("channel"), context, response["choices"][0].get("img_urls")))
                     thread.start()
-                    if response["choices"][0].get("text_content"):
-                        reply_content = response["choices"][0].get("text_content")
-                reply_content = self._process_url(reply_content)
+                    reply_content = response["choices"][0].get("text_content")
+                if reply_content:
+                    reply_content = self._process_url(reply_content)
                 return Reply(ReplyType.TEXT, reply_content)
 
             else:


### PR DESCRIPTION
修复当返回内容只有图片URLs时，链接解析成图片直接返回，同时又返回了链接的问题~