### PR TITLE
Fix: fix 'NoneType' object does not support item assignment error (#2525)

### DIFF
--- a/channel/chat_channel.py
+++ b/channel/chat_channel.py
@@ -146,6 +146,7 @@ class ChatChannel(Channel):
                 elif context["origin_ctype"] == ContextType.VOICE:  # 如果源消息是私聊的语音消息，允许不匹配前缀，放宽条件
                     pass
                 else:
+                    logger.info("[chat_channel]receive single chat msg, but checkprefix didn't match")
                     return None
             content = content.strip()
             img_match_prefix = check_prefix(content, conf().get("image_create_prefix",[""]))

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -156,11 +156,11 @@ class WebChannel(ChatChannel):
                                                                                      from_user_id=user_id,
                                                                                      other_user_id = user_id
                                                                                      ))
-            context["isgroup"] = False
-            # context["session"] = web.storage(session_id=user_id)
-            
             if not context:
                 return json.dumps({"status": "error", "message": "Failed to process message"})
+
+            context["isgroup"] = False
+            # context["session"] = web.storage(session_id=user_id)
                 
             self.produce(context)
             return json.dumps({"status": "success", "message": "Message received"})
@@ -176,7 +176,6 @@ class WebChannel(ChatChannel):
             return f.read()
 
     def startup(self):
-        logger.setLevel("WARN")
         print("\nWeb Channel is running, please visit http://localhost:9899/chat")
         
         urls = (


### PR DESCRIPTION
### Problem Description
When `context` is `None`, it should not be used for assignment operations.

### Solution
Adjusted the code logic to ensure that `context` is not `None` before performing any item assignment.