### PR TITLE
fix: 补充缺失的 runtime_info 参数传递

### DIFF
--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -233,7 +233,8 @@ class AgentBridge:
             enable_skills=kwargs.get("enable_skills", True),  # Enable skills by default
             memory_manager=kwargs.get("memory_manager"),  # Pass memory manager
             max_context_tokens=kwargs.get("max_context_tokens"),
-            context_reserve_tokens=kwargs.get("context_reserve_tokens")
+            context_reserve_tokens=kwargs.get("context_reserve_tokens"),
+            runtime_info=kwargs.get("runtime_info")  # Pass runtime_info for dynamic time updates
         )
 
         # Log skill loading details


### PR DESCRIPTION
## 问题描述

PR #2655 已成功合并，但遗漏了一个关键的参数传递环节，导致动态时间更新功能无法生效。

### 根本原因

参数传递链路不完整：

```
agent_initializer._get_runtime_info()  ✅ 创建 get_current_time 函数
  ↓
agent_initializer.initialize_agent()  ✅ 传递 runtime_info 参数
  ↓
agent_bridge.create_agent()           ❌ 未传递给 Agent
  ↓
Agent.__init__()                      ❌ self.runtime_info = None
```

### 影响范围

- Agent 实例的 `self.runtime_info` 为 `None`
- `get_full_system_prompt()` 无法检测到动态时间函数
- `_rebuild_runtime_section()` 不会被调用
- **结果**：时间戳仍然是静态的，不会实时更新

## 解决方案

在 `bridge/agent_bridge.py` 的 `create_agent()` 方法第 236 行添加：

```python
runtime_info=kwargs.get("runtime_info")  # Pass runtime_info for dynamic time updates
```

### 修复后的完整链路

```
agent_initializer._get_runtime_info()  ✅ 创建函数
  ↓
agent_initializer.initialize_agent()  ✅ runtime_info={'_get_current_time': fn}
  ↓
agent_bridge.create_agent()           ✅ 传递 runtime_info 参数
  ↓
Agent.__init__()                      ✅ self.runtime_info = {...}
  ↓
Agent.get_full_system_prompt()        ✅ 检测到 callable
  ↓
Agent._rebuild_runtime_section()      ✅ 动态获取最新时间
```

## 测试验证

可以通过以下方式验证修复是否生效：

```python
# 在 agent.py 的 get_full_system_prompt() 中添加日志
if self.runtime_info and callable(self.runtime_info.get('_get_current_time')):
    logger.info("[Agent] Detected dynamic time function, rebuilding runtime section")
    return self._rebuild_runtime_section(self.system_prompt)
```

如果看到日志输出，说明动态时间功能正常工作。

## 代码变更

- `bridge/agent_bridge.py`: +2 行, -1 行
  - 添加 `runtime_info` 参数传递

## 相关 PR

- PR #2655: 实现动态时间更新的核心逻辑（已合并）
- 本 PR: 补充遗漏的参数传递环节

---

*来自 [CowAgent](https://github.com/zhayujie/chatgpt-on-wechat) 项目的 AI Agent*