### PR TITLE
fix: 支持智谱AI自定义API base URL配置

### DIFF
--- a/models/zhipuai/zhipu_ai_image.py
+++ b/models/zhipuai/zhipu_ai_image.py
@@ -7,7 +7,16 @@ from config import conf
 class ZhipuAIImage(object):
     def __init__(self):
         from zai import ZhipuAiClient
-        self.client = ZhipuAiClient(api_key=conf().get("zhipu_ai_api_key"))
+        # 初始化客户端，支持自定义 API base URL（例如智谱国际版 z.ai）
+        api_key = conf().get("zhipu_ai_api_key")
+        api_base = conf().get("zhipu_ai_api_base")
+        
+        if api_base:
+            self.client = ZhipuAiClient(api_key=api_key, base_url=api_base)
+            logger.info(f"[ZHIPU_AI_IMAGE] 使用自定义 API Base URL: {api_base}")
+        else:
+            self.client = ZhipuAiClient(api_key=api_key)
+            logger.info("[ZHIPU_AI_IMAGE] 使用默认 API Base URL")
 
     def create_img(self, query, retry_count=0, api_key=None, api_base=None):
         try:

--- a/models/zhipuai/zhipuai_bot.py
+++ b/models/zhipuai/zhipuai_bot.py
@@ -24,7 +24,16 @@ class ZHIPUAIBot(Bot, ZhipuAIImage):
             "temperature": conf().get("temperature", 0.9),  # 值在(0,1)之间(智谱AI 的温度不能取 0 或者 1)
             "top_p": conf().get("top_p", 0.7),  # 值在(0,1)之间(智谱AI 的 top_p 不能取 0 或者 1)
         }
-        self.client = ZhipuAiClient(api_key=conf().get("zhipu_ai_api_key"))
+        # 初始化客户端，支持自定义 API base URL（例如智谱国际版 z.ai）
+        api_key = conf().get("zhipu_ai_api_key")
+        api_base = conf().get("zhipu_ai_api_base")
+        
+        if api_base:
+            self.client = ZhipuAiClient(api_key=api_key, base_url=api_base)
+            logger.info(f"[ZHIPU_AI] 使用自定义 API Base URL: {api_base}")
+        else:
+            self.client = ZhipuAiClient(api_key=api_key)
+            logger.info("[ZHIPU_AI] 使用默认 API Base URL")
 
     def reply(self, query, context=None):
         # acquire reply content


### PR DESCRIPTION
## 问题描述

修复 issue #2659 报告的问题：用户配置智谱国际版(z.ai) API 时，即使设置了 `zhipu_ai_api_base` 配置项，仍然无法正常使用，报错余额不足。

## 问题根因

`ZhipuAiClient` 初始化时没有传入 `base_url` 参数，导致配置文件中的 `zhipu_ai_api_base` 配置项完全不生效，客户端仍然请求默认的智谱国内版 API。

## 修复内容

1. **修改文件**：
   - `models/zhipuai/zhipuai_bot.py` - 对话功能
   - `models/zhipuai/zhipu_ai_image.py` - 图片生成功能

2. **修复逻辑**：
   - 在初始化 `ZhipuAiClient` 时读取 `zhipu_ai_api_base` 配置
   - 如果配置了自定义 API Base URL，则传入 `base_url` 参数
   - 如果未配置，则使用默认值（保持向后兼容）
   - 添加日志输出，方便用户确认使用的 API 地址

3. **使用示例**：

   **智谱国际版通用模型**：
   ```json
   {
     "zhipu_ai_api_key": "your_api_key",
     "zhipu_ai_api_base": "https://api.z.ai/api/paas/v4"
   }
   ```

   **智谱国际版 Coding Plan（代码专用）**：
   ```json
   {
     "zhipu_ai_api_key": "your_api_key",
     "zhipu_ai_api_base": "https://api.z.ai/api/coding/paas/v4"
   }
   ```

   > ⚠️ **重要提示**：使用 [GLM Coding Plan](https://docs.z.ai/devpack/overview) 时，需要配置专用的 Coding 端点 `https://api.z.ai/api/coding/paas/v4`，而不是通用端点 `https://api.z.ai/api/paas/v4`

## 测试建议

1. 配置智谱国际版 z.ai 的 API Key 和 Base URL
2. 启动服务，确认日志显示正确的 API 地址
3. 测试对话和图片生成功能

Fixes #2659