### PR TITLE
fix: handle non-string model_type to prevent AttributeError

### DIFF
--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -24,6 +24,13 @@ class Bridge(object):
             self.btype["chat"] = bot_type
         else:
             model_type = conf().get("model") or const.GPT_41_MINI
+            
+            # Ensure model_type is string to prevent AttributeError when using startswith()
+            # This handles cases where numeric model names (e.g., "1") are parsed as integers from YAML
+            if not isinstance(model_type, str):
+                logger.warning(f"[Bridge] model_type is not a string: {model_type} (type: {type(model_type).__name__}), converting to string")
+                model_type = str(model_type)
+            
             if model_type in ["text-davinci-003"]:
                 self.btype["chat"] = const.OPEN_AI
             if conf().get("use_azure_chatgpt", False):


### PR DESCRIPTION
## Description

Fixes #2664

When using vLLM with numeric model names (e.g., `"1"`), if the model name is configured in Docker Compose YAML without quotes (`MODEL: 1`), it gets parsed as an integer instead of a string. This causes `AttributeError: 'int' object has no attribute 'startswith'` when the bridge tries to check model type.

## Changes

- Add type checking for `model_type` in `bridge/bridge.py`
- Automatically convert non-string `model_type` to string
- Add warning log when type conversion occurs
- Fully backward compatible

## Testing

**Before fix:**
```yaml
MODEL: 1  # Parsed as int, causes AttributeError
```

**After fix:**
```yaml
MODEL: 1  # Converted to "1" with warning, works correctly
```

## Technical Details

The fix adds defensive programming at line 27-34 in `bridge/bridge.py`:
```python
if not isinstance(model_type, str):
    logger.warning(f"[Bridge] model_type is not a string: {model_type}")
    model_type = str(model_type)
```

This ensures all subsequent `startswith()` calls work correctly regardless of the input type.