### PR TITLE
fix: 微信公众号 token 验证失败问题

### DIFF
--- a/channel/wechatmp/active_reply.py
+++ b/channel/wechatmp/active_reply.py
@@ -16,7 +16,12 @@ from config import conf, subscribe_msg
 # This class is instantiated once per query
 class Query:
     def GET(self):
-        return verify_server(web.input())
+        response_data = verify_server(web.input())
+        # 显式设置 Content-Length 避免使用 chunked 编码
+        # 某些情况下微信公众号 token 验证不支持 chunked 编码
+        if response_data:
+            web.header("Content-Length", str(len(response_data)))
+        return response_data
 
     def POST(self):
         # Make sure to return the instance that first created, @singleton will do that.

--- a/channel/wechatmp/passive_reply.py
+++ b/channel/wechatmp/passive_reply.py
@@ -18,7 +18,12 @@ from config import conf, subscribe_msg
 # This class is instantiated once per query
 class Query:
     def GET(self):
-        return verify_server(web.input())
+        response_data = verify_server(web.input())
+        # 显式设置 Content-Length 避免使用 chunked 编码
+        # 某些情况下微信公众号 token 验证不支持 chunked 编码
+        if response_data:
+            web.header("Content-Length", str(len(response_data)))
+        return response_data
 
     def POST(self):
         try:


### PR DESCRIPTION
## 问题描述

修复 #1148 - 微信公众号 token 验证失败

## 根本原因

web.py 框架默认使用 `Transfer-Encoding: chunked` 方式返回 HTTP response，但在某些环境下，微信公众号的 token 验证接口不支持 chunked 编码，导致验证失败。

根据 issue 中 @zhourenjian 的分析：

- ❌ 使用 chunked 编码时验证失败：
```
< HTTP/1.1 200 OK
< Transfer-Encoding: chunked
< Date: Tue, 30 May 2023 10:16:03 GMT
< Server: localhost
< 
7678943348689730297
```

- ✅ 显式指定 Content-Length 时验证成功：
```
< HTTP/1.1 200 OK
< Content-Type: text/javascript
< Content-Length: 19
< 
767894334868973029
```

## 解决方案

在 `active_reply.py` 和 `passive_reply.py` 的 `Query.GET()` 方法中，显式设置 `Content-Length` header：

```python
class Query:
    def GET(self):
        response_data = verify_server(web.input())
        # 显式设置 Content-Length 避免使用 chunked 编码
        if response_data:
            web.header("Content-Length", str(len(response_data)))
        return response_data
```

## 测试

- [x] 代码已修改并提交
- [ ] 需要在实际微信公众号环境中测试

## 影响范围

- 仅影响微信公众号 channel 的 token 验证
- 不影响正常的消息收发功能
- 向后兼容，不会影响已经正常工作的环境

## 相关讨论

感谢 @zhourenjian 在 issue 中提供的详细分析和解决方案。

Closes #1148