### PR TITLE
fix: pass bot_type in agent mode

### DIFF
--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -97,6 +97,9 @@ class AgentLLMModel(LLMModel):
     def _resolve_bot_type(self, model_name: str) -> str:
         """Resolve bot type from model name, matching Bridge.__init__ logic."""
         from config import conf
+        configured_bot_type = conf().get("bot_type")
+        if configured_bot_type:
+            return configured_bot_type
         if conf().get("use_linkai", False) and conf().get("linkai_api_key"):
             return const.LINKAI
         if not model_name or not isinstance(model_name, str):


### PR DESCRIPTION
修复了在使用第三方模型服务时，agent模式下会无视config文件中bot_type的配置，而是依据model字段值选择模型请求路径格式