### PR TITLE
perf(channel): set a timeout on feishu channel HTTP calls

### DIFF
--- a/channel/feishu/feishu_channel.py
+++ b/channel/feishu/feishu_channel.py
@@ -491,7 +491,7 @@ class FeiShuChanel(ChatChannel):
             "app_secret": self.feishu_app_secret
         }
         data = bytes(json.dumps(req_body), encoding='utf8')
-        response = requests.post(url=url, data=data, headers=headers)
+        response = requests.post(url=url, data=data, headers=headers, timeout=10.0)
         if response.status_code == 200:
             res = response.json()
             if res.get("code") != 0:
@@ -520,7 +520,7 @@ class FeiShuChanel(ChatChannel):
             headers = {'Authorization': f'Bearer {access_token}'}
 
             with open(local_path, "rb") as file:
-                upload_response = requests.post(upload_url, files={"image": file}, data=data, headers=headers)
+                upload_response = requests.post(upload_url, files={"image": file}, data=data, headers=headers, timeout=10.0)
                 logger.info(f"[FeiShu] upload file, res={upload_response.content}")
 
                 response_data = upload_response.json()


### PR DESCRIPTION
Small fix for a missing request timeout in channel/feishu/feishu_channel.py.

Network calls without a timeout can hang a worker indefinitely.

Ran: `/Users/tejasattarde/Downloads/gh-patchbot/.venv/bin/python3.14 -m py_compile channel/feishu/feishu_channel.py`.

`feishu/feishu_channel.py` line 494.