### PR TITLE
fix: add missing model property to GoogleGeminiBot

### DIFF
--- a/models/gemini/google_gemini_bot.py
+++ b/models/gemini/google_gemini_bot.py
@@ -35,6 +35,13 @@ class GoogleGeminiBot(Bot):
         return conf().get("gemini_api_key")
 
     @property
+    def model(self):
+        model_name = conf().get("model") or "gemini-pro"
+        if model_name == "gemini":
+            model_name = "gemini-pro"
+        return model_name
+
+    @property
     def api_base(self):
         base = conf().get("gemini_api_base", "").strip()
         if base:


### PR DESCRIPTION
## Problem

After recent refactoring, `api_key` and `api_base` in `GoogleGeminiBot` were converted to `@property` descriptors, but `self.model` was not migrated accordingly.

This causes the following error when using any Gemini model:

```
AttributeError: 'GoogleGeminiBot' object has no attribute 'model'
Traceback (most recent call last):
  File "/app/models/gemini/google_gemini_bot.py", line 60, in reply
    model=self.model
```

## Fix

Add a `model` property consistent with the existing `api_key` and `api_base` properties:

```python
@property
def model(self):
    model_name = conf().get("model") or "gemini-pro"
    if model_name == "gemini":
        model_name = "gemini-pro"
    return model_name
```

As a bonus, this means model name changes in config now take effect without restarting.