### PR TITLE
fix: Fix run.sh for MacOS via add timeout fallback

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,20 @@ if [ -z "$BASH_VERSION" ]; then
     exit 1
 fi
 
+# Fallback for 'timeout' on macOS where GNU Coreutils is not installed by default.
+# If 'gtimeout' (Homebrew's coreutils) is present, we use it. Otherwise, we gracefully
+# degrade by using `shift` to discard the time limit argument ($1) and executing the rest of the command.
+if ! command -v timeout &> /dev/null; then
+    timeout() {
+        if command -v gtimeout &> /dev/null; then
+            gtimeout "$@"
+        else
+            shift
+            "$@"
+        fi
+    }
+fi
+
 # Get current script directory
 export BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 


### PR DESCRIPTION
### Problem

The `timeout` command (GNU Coreutils) is not available by default on macOS, causing the installation script to fail with:

```
/dev/fd/11: line 178: timeout: command not found
⚠️  GitHub clone failed or timed out, switching to Gitee mirror...
/dev/fd/11: line 182: timeout: command not found
❌ Project clone failed. Please check network connection.
```

when running `bash <(curl -fsSL https://cdn.link-ai.tech/code/cow/run.sh)` on macOS.

### Solution

Added a shell function fallback near the top of `run.sh` that:
- Uses `gtimeout` if Homebrew's `coreutils` package is installed
- Otherwise gracefully degrades by skipping the timeout constraint and running the command directly

This is a minimal, non-breaking change — Linux behavior is completely unchanged since the native `timeout` command will be found and the fallback is never defined.