### PR TITLE
fix: remember scheduled task outputs

### DIFF
--- a/agent/tools/scheduler/integration.py
+++ b/agent/tools/scheduler/integration.py
@@ -84,6 +84,31 @@ def get_scheduler_service():
     return _scheduler_service
 
 
+def _remember_delivered_output(
+    agent_bridge,
+    receiver: str,
+    channel_type: str,
+    content: str,
+    task_description: str = "",
+) -> None:
+    """Best-effort persistence of the message the scheduler sent to a user."""
+    if not receiver or not content:
+        return
+    try:
+        remember = getattr(agent_bridge, "remember_scheduled_output", None)
+        if remember:
+            remember(
+                receiver,
+                str(content),
+                channel_type=channel_type,
+                task_description=task_description,
+            )
+    except Exception as e:
+        logger.warning(
+            f"[Scheduler] Failed to remember delivered output for {receiver}: {e}"
+        )
+
+
 def _execute_agent_task(task: dict, agent_bridge):
     """
     Execute an agent_task action - let Agent handle the task
@@ -165,6 +190,13 @@ def _execute_agent_task(task: dict, agent_bridge):
                         
                         # Send the reply
                         channel.send(reply, context)
+                        _remember_delivered_output(
+                            agent_bridge,
+                            receiver,
+                            channel_type,
+                            reply.content,
+                            task_description,
+                        )
                         logger.info(f"[Scheduler] Task {task['id']} executed successfully, result sent to {receiver}")
                     else:
                         logger.error(f"[Scheduler] Failed to create channel: {channel_type}")
@@ -255,6 +287,13 @@ def _execute_send_message(task: dict, agent_bridge):
                     logger.debug(f"[Scheduler] Registered request_id {request_id} -> session {receiver}")
                 
                 channel.send(reply, context)
+                _remember_delivered_output(
+                    agent_bridge,
+                    receiver,
+                    channel_type,
+                    content,
+                    "send_message",
+                )
                 logger.info(f"[Scheduler] Task {task['id']} executed: sent message to {receiver}")
             else:
                 logger.error(f"[Scheduler] Failed to create channel: {channel_type}")
@@ -351,6 +390,13 @@ def _execute_tool_call(task: dict, agent_bridge):
                     logger.debug(f"[Scheduler] Registered request_id {request_id} -> session {receiver}")
 
                 channel.send(reply, context)
+                _remember_delivered_output(
+                    agent_bridge,
+                    receiver,
+                    channel_type,
+                    content,
+                    f"tool_call: {tool_name}",
+                )
                 logger.info(f"[Scheduler] Task {task['id']} executed: sent tool result to {receiver}")
             else:
                 logger.error(f"[Scheduler] Failed to create channel: {channel_type}")

--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -634,6 +634,46 @@ class AgentBridge:
                 f"[AgentBridge] Failed to persist messages for session={session_id}: {e}"
             )
 
+    def remember_scheduled_output(
+        self,
+        session_id: str,
+        content: str,
+        channel_type: str = "",
+        task_description: str = "",
+    ) -> None:
+        """
+        Add the visible output of a scheduled task to the receiver's session.
+
+        Scheduled task execution uses an isolated session so internal planning and
+        tool calls do not leak into the user's chat. The final message is still
+        part of the conversation from the user's point of view, so keep a small
+        visible turn in the receiver session for follow-up questions.
+        """
+        if not session_id or not content:
+            return
+
+        user_text = "Scheduled task"
+        if task_description:
+            user_text = f"{user_text}: {task_description}"
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": user_text}]},
+            {"role": "assistant", "content": [{"type": "text", "text": content}]},
+        ]
+
+        agent = self.agents.get(session_id)
+        if agent:
+            try:
+                with agent.messages_lock:
+                    agent.messages.extend(messages)
+            except Exception as e:
+                logger.warning(
+                    f"[AgentBridge] Failed to update in-memory scheduled output "
+                    f"for session={session_id}: {e}"
+                )
+
+        self._persist_messages(session_id, messages, channel_type)
+
     @staticmethod
     def _strip_thinking_blocks(messages: list) -> list:
         """Return a shallow copy of messages with assistant "thinking" blocks removed."""


### PR DESCRIPTION
Summary
- keep scheduler execution isolated from the user chat
- remember the final delivered scheduler message in the receiver session
- apply it after successful `agent_task`, `send_message`, and `tool_call` sends

Validation
- `python3 -m py_compile agent/tools/scheduler/integration.py bridge/agent_bridge.py`
- `git diff --check`

Fixes #2793
