### PR TITLE
feat(web): auto-switch port on conflict and open browser on startup

### DIFF
--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -535,24 +535,8 @@ class WebChannel(ChatChannel):
         with open(file_path, 'r', encoding='utf-8') as f:
             return f.read()
 
-    def _find_available_port(self, start_port, max_tries=10):
-        """从 start_port 开始向上找第一个可用端口，最多尝试 max_tries 次。"""
-        import socket
-        for port in range(start_port, start_port + max_tries):
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                try:
-                    s.bind(("0.0.0.0", port))
-                    return port
-                except OSError:
-                    continue
-        raise OSError(f"[WebChannel] 无法找到可用端口（尝试范围 {start_port}-{start_port + max_tries - 1}）")
-
     def startup(self):
-        base_port = conf().get("web_port", 9899)
-        port = self._find_available_port(base_port)
-        if port != base_port:
-            logger.info(f"[WebChannel] 端口 {base_port} 已被占用，自动切换到端口 {port}")
+        port = conf().get("web_port", 9899)
 
         # 打印可用渠道类型提示
         logger.info(
@@ -570,8 +554,12 @@ class WebChannel(ChatChannel):
         logger.info(f"[WebChannel] 🌐 本地访问: http://localhost:{port}")
         logger.info(f"[WebChannel] 🌍 服务器访问: http://YOUR_IP:{port} (请将YOUR_IP替换为服务器IP)")
 
-        import webbrowser
-        webbrowser.open(f"http://localhost:{port}")
+        try:
+            import webbrowser
+            webbrowser.open(f"http://localhost:{port}")
+            logger.debug(f"[WebChannel] Opened browser at http://localhost:{port}")
+        except Exception as e:
+            logger.debug(f"[WebChannel] Could not open browser: {e}")
 
         # 确保静态文件目录存在
         static_dir = os.path.join(os.path.dirname(__file__), 'static')
@@ -638,6 +626,13 @@ class WebChannel(ChatChannel):
             server.start()
         except (KeyboardInterrupt, SystemExit):
             server.stop()
+        except OSError as e:
+            if e.errno in (48, 98):  # macOS/Linux EADDRINUSE
+                logger.error(
+                    f"[WebChannel] 端口 {port} 已被占用，可执行 `cow restart` 清理残留进程，"
+                    f"或在 config.json 中修改 web_port"
+                )
+            raise
 
     def stop(self):
         if self._http_server:

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -535,8 +535,24 @@ class WebChannel(ChatChannel):
         with open(file_path, 'r', encoding='utf-8') as f:
             return f.read()
 
+    def _find_available_port(self, start_port, max_tries=10):
+        """从 start_port 开始向上找第一个可用端口，最多尝试 max_tries 次。"""
+        import socket
+        for port in range(start_port, start_port + max_tries):
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                try:
+                    s.bind(("0.0.0.0", port))
+                    return port
+                except OSError:
+                    continue
+        raise OSError(f"[WebChannel] 无法找到可用端口（尝试范围 {start_port}-{start_port + max_tries - 1}）")
+
     def startup(self):
-        port = conf().get("web_port", 9899)
+        base_port = conf().get("web_port", 9899)
+        port = self._find_available_port(base_port)
+        if port != base_port:
+            logger.info(f"[WebChannel] 端口 {base_port} 已被占用，自动切换到端口 {port}")
 
         # 打印可用渠道类型提示
         logger.info(
@@ -553,6 +569,9 @@ class WebChannel(ChatChannel):
         logger.info("[WebChannel] ✅ Web控制台已运行")
         logger.info(f"[WebChannel] 🌐 本地访问: http://localhost:{port}")
         logger.info(f"[WebChannel] 🌍 服务器访问: http://YOUR_IP:{port} (请将YOUR_IP替换为服务器IP)")
+
+        import webbrowser
+        webbrowser.open(f"http://localhost:{port}")
 
         # 确保静态文件目录存在
         static_dir = os.path.join(os.path.dirname(__file__), 'static')


### PR DESCRIPTION
## 背景

Web 控制台默认监听 `9899` 端口。当该端口已被占用时（例如上一个进程未正常退出），`cow start` 会抛出 `OSError: Address already in use` 异常并直接崩溃，导致 Web 控制台完全不可用，用户需要手动排查端口占用才能重启。

此外，服务启动成功后用户需要手动打开浏览器并输入地址，体验不够流畅。

## 改动动机

- 消除因端口冲突导致的启动失败，提升可用性
- 减少用户操作步骤，服务就绪后自动打开控制台页面

## 改动内容

**`channel/web/web_channel.py`**

1. 新增 `_find_available_port(start_port, max_tries=10)` 方法：从配置端口开始向上探测，找到第一个可用端口（最多尝试 10 个）
2. `startup()` 中替换为动态端口，端口切换时打印 warning 提示
3. 服务启动日志打印后调用 `webbrowser.open()` 打开本地控制台页面

该逻辑放在 `web_channel.py` 而非 CLI 层，原因是：
- `web_channel.py` 知道实际监听的端口（含自动递增后的值），CLI 层只能读配置文件中的原始值
- 浏览器应在服务真正就绪后打开，而不是在进程刚 fork 出来时

## 副作用

- 端口切换后控制台地址变化，用户需注意 warning 日志中的实际端口
- 每次启动都会触发系统默认浏览器打开，若在无 GUI 的服务器环境运行，`webbrowser.open()` 会静默失败（无副作用）

## 验证步骤

1. 正常启动：`cow start`，确认浏览器自动打开 `http://localhost:9899`
2. 端口占用：手动占用 9899 端口后再 `cow start`，确认日志打印 warning 并自动切换到 9900，浏览器打开正确地址
3. 服务器环境：在无 GUI 环境下启动，确认不报错，服务正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)