### PR TITLE
feat(cli): prompt user to stop process on Ctrl+C after cow start

### DIFF
--- a/cli/commands/process.py
+++ b/cli/commands/process.py
@@ -136,6 +136,14 @@ def start(foreground, no_logs):
         if not no_logs:
             click.echo("  Press Ctrl+C to stop tailing logs.\n")
             _tail_log(log_file)
+            # Ctrl+C pressed — ask user whether to stop the process
+            click.echo("")
+            if click.confirm("是否同时终止 CowAgent 进程?", default=False):
+                with click.Context(stop) as ctx:
+                    stop.invoke(ctx)
+            else:
+                pid = _read_pid()
+                click.echo(f"日志输出已停止，进程仍在运行 (PID: {pid})，您可使用 cow stop 终止进程")
 
 
 @click.command()


### PR DESCRIPTION
## 背景

`cow start` 以后台进程（nohup）方式启动 CowAgent，然后进入日志 tail 模式。用户按下 Ctrl+C 时，原有行为只是停止日志输出，进程仍在后台运行。这对不熟悉该机制的用户容易造成困惑：以为按了 Ctrl+C 就停止了服务，实际上服务仍在运行。

## 改动动机

让 Ctrl+C 的行为符合用户直觉，同时保留"只停止 tail、不终止进程"的灵活性。

## 改动内容

**`cli/commands/process.py`**

`_tail_log()` 返回（即捕获到 `KeyboardInterrupt`）后，通过 `click.confirm()` 询问用户是否同时终止进程：
- 选择 **是**：调用 `stop` 命令终止后台进程
- 选择 **否**（或直接回车）：打印提示 `日志输出已停止，进程仍在运行 (PID: xxx)，您可使用 cow stop 终止进程`

复用已有的 `stop` 命令（`stop.invoke(click.Context(stop))`），避免重复逻辑。

## 副作用

- 原来 Ctrl+C 是即时响应，现在会多一次交互确认，略微增加操作步骤
- 若终端处于非交互模式（如管道、脚本调用），`click.confirm()` 会使用默认值 `False`，即不终止进程

## 验证步骤

1. `cow start` 启动后按 Ctrl+C，确认出现确认提示
2. 输入 `y`，确认进程被终止（`cow status` 显示未运行）
3. 再次启动，按 Ctrl+C 后直接回车，确认进程仍在运行并打印正确提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)