### PR TITLE
fix(app): suppress KeyboardInterrupt traceback on Ctrl+C

### DIFF
--- a/app.py
+++ b/app.py
@@ -360,6 +360,8 @@ def run():
 
         while True:
             time.sleep(1)
+    except KeyboardInterrupt:
+        pass
     except Exception as e:
         logger.error("App startup failed!")
         logger.exception(e)


### PR DESCRIPTION
## 背景

使用 `python app.py` 启动后按 Ctrl+C，终端会打印如下 traceback，看起来像是程序崩溃：

```
^C[INFO][2026-05-10 17:05:30][app.py:268] - signal 2 received, exiting...
[INFO][2026-05-10 17:05:30][config.py:291] - [Config] User datas saved.
Traceback (most recent call last):
  File "app.py", line 369, in <module>
    run()
  File "app.py", line 362, in run
    time.sleep(1)
  File "app.py", line 271, in func
    return old_handler(_signo, _stack_frame)
KeyboardInterrupt
```

实际上数据已保存、退出流程已完成，只是 traceback 造成了视觉噪音。

## 复现步骤

1. `python app.py` 启动项目
2. 按下 Ctrl+C
3. 观察到 traceback 输出

## 根本原因

调用链如下：

```
Ctrl+C
  → 触发 SIGINT
    → sigterm_handler_wrap 注册的 func() 执行清理（打印日志、保存数据）
      → 调用 old_handler()（Python 默认 SIGINT 处理器）
        → 抛出 KeyboardInterrupt
          → 从 time.sleep(1) 处冒出
            → run() 中的 except Exception 捕获不到（KeyboardInterrupt 继承自 BaseException）
              → 打印 traceback
```

`sigterm_handler_wrap` 同时注册了 SIGINT 和 SIGTERM，两者的 `old_handler` 行为不同：
- **SIGINT**：`old_handler` 是 Python 默认处理器，抛出 `KeyboardInterrupt`，触发 traceback
- **SIGTERM**：`old_handler` 通常是 `SIG_DFL`，直接终止进程，不抛异常

因此问题**仅在 Ctrl+C（SIGINT）时出现**。

## 可选方案

**方案 A（本 PR 采用）：在 `run()` 中捕获 `KeyboardInterrupt`**

```python
except KeyboardInterrupt:
    pass
```

优点：改动最小，不影响信号处理链  
缺点：若启动阶段内部抛出 `KeyboardInterrupt`（极罕见），会被静默吞掉

**方案 B：在信号处理函数中用 `sys.exit(0)` 替代 `old_handler`**

```python
def func(_signo, _stack_frame):
    logger.info("signal {} received, exiting...".format(_signo))
    conf().save_user_datas()
    sys.exit(0)  # 不再调用 old_handler
```

优点：从根源解决问题，`KeyboardInterrupt` 不再被抛出  
缺点：跳过了 `old_handler`，若其他模块（如第三方库）注册了 SIGINT/SIGTERM 的清理逻辑，将不会被执行

## 选择方案 A 的理由

方案 B 改动信号处理链，存在跳过第三方库清理逻辑的风险，影响范围更广。方案 A 改动范围最小，仅在 `run()` 的主循环出口处静默捕获，不影响任何已有的退出逻辑。由于清理工作（保存数据、打印日志）在信号处理阶段已完成，`KeyboardInterrupt` 传播到此处时已无实际意义，静默处理是合理的。

## 副作用

启动阶段（`_channel_mgr.start()` 内部）若意外触发 `KeyboardInterrupt`，会被静默吞掉。实际上 `KeyboardInterrupt` 只由用户主动按 Ctrl+C 触发，此场景极不可能在 `start()` 内部发生。

## 验证步骤

1. `python app.py` 启动项目
2. 按下 Ctrl+C
3. 确认只打印 `signal 2 received, exiting...` 和数据保存日志，无 traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)