### PR TITLE
fix(wecom_bot): Invalid control character

### DIFF
--- a/channel/wecom_bot/wecom_bot_channel.py
+++ b/channel/wecom_bot/wecom_bot_channel.py
@@ -34,6 +34,50 @@ HEARTBEAT_INTERVAL = 30
 MEDIA_CHUNK_SIZE = 512 * 1024  # 512KB per chunk (before base64 encoding)
 
 
+def _escape_control_chars_inside_json_strings(s: str) -> str:
+    """Escape U+0000–U+001F inside JSON string values so json.loads accepts WeCom payloads.
+
+    The server occasionally emits raw newlines/tabs inside quoted fields, which is
+    invalid strict JSON but recoverable without touching escapes like \\n or \\".
+    """
+    out = []
+    in_string = False
+    escape = False
+    for c in s:
+        if escape:
+            out.append(c)
+            escape = False
+            continue
+        if in_string and c == "\\":
+            out.append(c)
+            escape = True
+            continue
+        if c == '"':
+            out.append(c)
+            in_string = not in_string
+            continue
+        if in_string and ord(c) < 32:
+            out.append("\\u%04x" % ord(c))
+            continue
+        out.append(c)
+    return "".join(out)
+
+
+def _loads_wecom_ws_json(raw):
+    """Parse WebSocket JSON; tolerate unescaped control characters inside strings."""
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="replace")
+    if not isinstance(raw, str):
+        raw = str(raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        msg = str(e).lower()
+        if "control character" in msg:
+            return json.loads(_escape_control_chars_inside_json_strings(raw))
+        raise
+
+
 @singleton
 class WecomBotChannel(ChatChannel):
 
@@ -93,7 +137,7 @@ class WecomBotChannel(ChatChannel):
 
         def _on_message(ws, raw):
             try:
-                data = json.loads(raw)
+                data = _loads_wecom_ws_json(raw)
                 self._handle_ws_message(data)
             except Exception as e:
                 logger.error(f"[WecomBot] Failed to handle ws message: {e}", exc_info=True)


### PR DESCRIPTION

### 现象

日志中出现类似错误：

```text
JSONDecodeError: Invalid control character at: line 1 column 512 (char 511)
```

出现在 `wecom_bot_channel.py` 对 WebSocket 消息做 `json.loads` 时。

### 原因

企业微信网关下发的 JSON 中，**字符串字段内**有时含有**未转义的控制字符**，例如：

- 消息正文里的真实换行 `\n`、回车 `\r`；
- 从串口/终端复制来的 **ANSI 颜色与控制序列**（以 `ESC` / `0x1B` 开头，如 `\033[0;32m` … `\033[0m`），在 JSON 字符串里同样属于非法控制字符。

严格 JSON 要求这些字符必须写成 `\n`、`\u001b` 等形式，标准库 `json.loads` 会直接报错。用户若把设备日志整段贴进会话，极易触发上述问题。

### 典型异常日志示例（含 ANSI 与芯片复位）

以下为 **ESP-IDF 串口日志** 示例：既含 ANSI 高亮，又含 **RTC 看门狗复位**（`rst:0x10 (RTCWDT_RTC_RST)`）后的 ROM/bootloader 启动信息。此类内容经网关封装进 WebSocket JSON 时，若无转义，会与「Invalid control character」同源。

```text
32mI (31492) MQTTS_DEMO: reconnecttime:1[0m
[0;32mI (31492) MQTTS_DEMO: esp_mqtt_set_config OK[0m
[0;32mI (31502) uart: GetIOTConnStatusUpload[0m
[0;32mI (31512) uart: send_P2P_FR[0m
I (31612) wifi:flush txq
I (31612) wifi:stop sw txq
ESP-ROM:esp8684-api2-20220127
Build:Jan 27 2022
rst:0x10 (RTCWDT_RTC_RST),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5c80,len:0x1660
load:0x403acb70,len:0x968
load:0x403aeb70,len:0x27d8
entry 0x403acb70
[0;32mI (33) boot: ESP-IDF v5.0.1-dirty 2nd stage bootloader[0m
[0;32mI (33) boot: compile time 10:56:23[0m
[0;32mI (33) boot: chip revision: v1.0[0m
[0;32mI (37) boot.esp32c2: MMU Page Size  : 64K[0m
[0;32mI (44) boot.esp32c2: SPI Speed      : 60MHz[0m
[0;32mI (52) boot.esp32c2: SPI Mode       : DIO[0m
[0;32mI (59) boot.esp32c2: SPI Flash Size : 4MB[0m
[0;32mI (66) boot: Enabling RNG early entropy source...[0m
```

### 处理

在 `wecom_bot_channel.py` 中：

- 使用 **`_loads_wecom_ws_json`** 替代裸 `json.loads(raw)`。
- 若首次解析失败且错误与 **control character** 相关，则对原文做一次 **`_escape_control_chars_inside_json_strings`**：仅在「引号对内的字符串内容」里，把 `U+0000`–`U+001F` 转为 `\u00xx`，再 `json.loads`。
- 若 `raw` 为 **bytes**，先按 UTF-8 解码（非法字节用替换策略），再解析。
