### PR TITLE
feat: /command matching

### DIFF
--- a/plugins/cow_cli/cow_cli.py
+++ b/plugins/cow_cli/cow_cli.py
@@ -23,6 +23,7 @@ from plugins import Plugin, Event, EventContext, EventAction
 from bridge.context import ContextType
 from bridge.reply import Reply, ReplyType
 from common.log import logger
+from config import conf
 from cli import __version__
 
 
@@ -44,6 +45,23 @@ CLI_ONLY_COMMANDS = {"start", "stop", "restart"}
 # Commands that can only run from chat (need access to in-process memory)
 CHAT_ONLY_COMMANDS = set()  # context is allowed in both, but behaves differently
 
+# Convenience shorthands for the slash form only. Values are *full command
+# strings* so an alias can carry arguments (e.g. "cc" -> "context clear").
+# These shorthands are deliberate and NOT derivable from prefix/typo rules:
+#   - "c"  is a prefix of cancel/config/context (ambiguous) -> needs explicit map
+#   - "cc" is a prefix of nothing and expands to a command + argument
+#   - "s"  would otherwise be an ambiguous prefix (skill/start/status/stop)
+# Users may override / extend these via config.json "command_aliases".
+DEFAULT_ALIASES = {
+    "c":   "cancel",
+    "cc":  "context clear",
+    "ctx": "context",
+    "h":   "help",
+    "s":   "status",
+    "cfg": "config",
+    "k":   "knowledge",
+}
+
 
 @plugins.register(
     name="cow_cli",
@@ -57,7 +75,50 @@ class CowCliPlugin(Plugin):
     def __init__(self):
         super().__init__()
         self.handlers[Event.ON_HANDLE_CONTEXT] = self.on_handle_context
+        self.aliases = self._build_aliases()
         logger.debug("[CowCli] initialized")
+
+    def reload(self):
+        """Rebuild the alias table (e.g. after config changes)."""
+        self.aliases = self._build_aliases()
+
+    @staticmethod
+    def _build_aliases() -> dict:
+        """Merge DEFAULT_ALIASES with optional config.json ``command_aliases``.
+
+        User-supplied entries (keys lowercased / stripped) override defaults.
+        An alias whose target's first token is not a known command is dropped
+        with a warning, so a bad alias can never create a dead command. An
+        alias key that shadows a real command is kept but warned about — the
+        exact-command stage in ``_resolve`` runs first, so the command wins.
+        """
+        merged = dict(DEFAULT_ALIASES)
+        try:
+            overrides = conf().get("command_aliases", {}) or {}
+        except Exception as e:
+            logger.warning(f"[CowCli] could not read command_aliases from config: {e}")
+            overrides = {}
+        if not isinstance(overrides, dict):
+            logger.warning(f"[CowCli] command_aliases must be an object, got {type(overrides).__name__}; ignoring")
+            overrides = {}
+        for key, value in overrides.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                logger.warning(f"[CowCli] ignoring non-string alias entry: {key!r} -> {value!r}")
+                continue
+            k = key.strip().lower()
+            if k:
+                merged[k] = value.strip()
+
+        valid = {}
+        for key, value in merged.items():
+            head = value.split(None, 1)[0].lower() if value.strip() else ""
+            if head not in KNOWN_COMMANDS:
+                logger.warning(f"[CowCli] dropping alias '/{key}' -> '{value}': unknown command '{head}'")
+                continue
+            if key in KNOWN_COMMANDS:
+                logger.warning(f"[CowCli] alias '/{key}' shadows a real command; the command takes precedence")
+            valid[key] = value
+        return valid
 
     def on_handle_context(self, e_context: EventContext):
         if e_context["context"].type != ContextType.TEXT:
@@ -68,28 +129,24 @@ class CowCliPlugin(Plugin):
         if parsed is None:
             return
 
-        cmd, args = parsed
+        token, user_args = parsed
+        result = self._resolve(token, user_args)
+        kind = result[0]
 
-        if cmd not in KNOWN_COMMANDS:
-            # Slash-prefixed near-miss: looks like a typo of a real command.
-            # Intercept with a hint so we don't burn an LLM round on "/momory".
-            suggestion = self._suggest_command(cmd)
-            if suggestion is None:
-                return
-            hint = f"未知命令: /{cmd}"
-            if suggestion:
-                hint += f"\n你是不是想输入 /{suggestion} ?"
-            hint += "\n发送 /help 查看全部命令。"
-            e_context["reply"] = Reply(ReplyType.TEXT, hint)
-            e_context.action = EventAction.BREAK_PASS
+        if kind == "passthrough":
+            # Not a command and not a near-typo: let the agent handle it.
             return
 
-        logger.info(f"[CowCli] intercepted command: {cmd} {args}")
+        if kind == "run":
+            _, cmd, args = result
+            logger.info(f"[CowCli] intercepted command: {cmd} {args}")
+            reply_text = self._dispatch(cmd, args, e_context)
+        elif kind == "ambiguous":
+            reply_text = self._ambiguous_hint(token, result[1])
+        else:  # "typo"
+            reply_text = self._typo_hint(token, result[1])
 
-        result = self._dispatch(cmd, args, e_context)
-
-        reply = Reply(ReplyType.TEXT, result)
-        e_context["reply"] = reply
+        e_context["reply"] = Reply(ReplyType.TEXT, reply_text)
         e_context.action = EventAction.BREAK_PASS
 
     def _parse_command(self, content: str):
@@ -175,6 +232,69 @@ class CowCliPlugin(Plugin):
                 return known
         return None
 
+    def _resolve(self, token: str, user_args: str):
+        """Resolve a parsed slash token to an action.
+
+        Precedence (first hit wins):
+          1. exact command            -> ("run", cmd, args)
+          2. alias (exact key)        -> expand to a full command string, merge args
+          3. unique prefix            -> ("run", cmd, args)
+          4. ambiguous prefix (>1)    -> ("ambiguous", sorted_candidates)
+          5. typo (edit-distance <=1) -> ("typo", suggestion_or_None)
+          6. no match                 -> ("passthrough",)
+
+        Pure function of (token, user_args, KNOWN_COMMANDS, self.aliases) so it
+        is trivially unit-testable. Note the `cow ` form never reaches stages
+        2-5: `_parse_command` only returns known tokens for it, so it stays
+        strict and alias/prefix matching applies to the `/` form only.
+        """
+        token = token.lower()
+
+        # 1. exact command (a real command can never be shadowed by an alias)
+        if token in KNOWN_COMMANDS:
+            return ("run", token, user_args)
+
+        # 2. alias -> full command string; merge alias args with user args.
+        #    Alias expansion is applied at most once (no alias -> alias chains).
+        if token in self.aliases:
+            parts = self.aliases[token].split(None, 1)
+            cmd = parts[0].lower()
+            alias_args = parts[1] if len(parts) > 1 else ""
+            merged = f"{alias_args} {user_args}".strip() if user_args else alias_args
+            return ("run", cmd, merged)
+
+        # 3 / 4. prefix match
+        candidates = sorted(c for c in KNOWN_COMMANDS if c.startswith(token))
+        if len(candidates) == 1:
+            return ("run", candidates[0], user_args)
+        if len(candidates) > 1:
+            return ("ambiguous", candidates)
+
+        # 5. typo (keeps its own len>=3 + edit-distance<=1 guards)
+        suggestion = self._suggest_command(token)
+        if suggestion is not None:
+            return ("typo", suggestion)
+
+        # 6. nothing matched
+        return ("passthrough",)
+
+    @staticmethod
+    def _typo_hint(token: str, suggestion) -> str:
+        hint = f"未知命令: /{token}"
+        if suggestion:
+            hint += f"\n你是不是想输入 /{suggestion} ?"
+        hint += "\n发送 /help 查看全部命令。"
+        return hint
+
+    @staticmethod
+    def _ambiguous_hint(token: str, candidates) -> str:
+        options = " ".join(f"/{c}" for c in candidates)
+        return (
+            f"命令不明确: /{token}\n"
+            f"可能想输入: {options}\n"
+            "发送 /help 查看全部命令。"
+        )
+
     # ------------------------------------------------------------------
     # Command dispatch
     # ------------------------------------------------------------------
@@ -190,17 +310,17 @@ class CowCliPlugin(Plugin):
         parsed = self._parse_command(query.strip())
         if parsed is None:
             return None
-        cmd, args = parsed
-        if cmd not in KNOWN_COMMANDS:
-            suggestion = self._suggest_command(cmd)
-            if suggestion is None:
-                return None
-            hint = f"未知命令: /{cmd}"
-            if suggestion:
-                hint += f"\n你是不是想输入 /{suggestion} ?"
-            hint += "\n发送 /help 查看全部命令。"
-            return hint
-        return self._dispatch(cmd, args, e_context=None, session_id=session_id)
+        token, user_args = parsed
+        result = self._resolve(token, user_args)
+        kind = result[0]
+        if kind == "passthrough":
+            return None
+        if kind == "run":
+            _, cmd, args = result
+            return self._dispatch(cmd, args, e_context=None, session_id=session_id)
+        if kind == "ambiguous":
+            return self._ambiguous_hint(token, result[1])
+        return self._typo_hint(token, result[1])  # "typo"
 
     def _dispatch(self, cmd: str, args: str, e_context: EventContext, session_id: str = "") -> str:
         if cmd in CLI_ONLY_COMMANDS:


### PR DESCRIPTION
## 关联 Issue
- 关联 #2849

---

## 概述
本 PR 实现了基于 `/` 前缀命令的模糊解析系统与自定义别名

基于 `plugins/cow_cli/cow_cli.py` 的解析与分发逻辑，支持内置快捷别名（如 `/c`, `/cc`, `/s` 等）、唯一前缀快捷匹配（如 `/mem` -> `memory`）以及用户在 `config.json` 中自定义的别名。同时提供完善的防冲突校验与歧义匹配拦截，避免无效大模型请求及关键命令误执行。

---

## 主要改动

### 1. 核心解析器
- 在 `cow_cli.py` 中实现了纯函数解析器 `_resolve(token, user_args, KNOWN_COMMANDS, ALIASES)`。
- 解析器严格遵循以下优先级：
  1. **完全匹配**：如果命令匹配 `KNOWN_COMMANDS` 中的某个指令，立即执行。
  2. **别名扩展**：匹配内置或配置中合并的别名，支持将参数与用户追加的参数融合，并单次重解析（避免无限别名循环）。
  3. **唯一前缀**：如果输入是且仅是唯一一个已知命令的前缀，则执行该命令。
  4. **歧义前缀**：如果输入匹配多个已知命令（如 `/co` 匹配 `config` 和 `context`），则中止执行，并返回推荐提示。
  5. **拼写错误提示**：对于长度 ≥ 3 且同首字母、编辑距离 ≤ 1 的错别字进行提示（如 `/momory` -> `memory`）。
  6. **直接透传**：无任何匹配项时，传给模型。

### 2. 别名管理
- 定义了内置的 `DEFAULT_ALIASES`：
  ```python
  DEFAULT_ALIASES = {
      "c":   "cancel",
      "cc":  "context clear",
      "ctx": "context",
      "h":   "help",
      "s":   "status",
      "cfg": "config",
      "k":   "knowledge",
  }
  ```

- 支持从 `config.json` 的 `command_aliases` 配置块中读取并融合用户自定义别名。

---

## 验证与测试

为防止干扰, 测试文件未上传, 逻辑:

- 运行测试命令：
- 覆盖的关键测试用例：
  - `/memory` -> 执行 `memory`
  - `/mem` -> 执行 `memory` （唯一前缀）
  - `/c` -> 执行内置别名 `cancel`
  - `/cc foo` -> 展开别名并带参数执行 `context clear foo`
  - `/co` -> 匹配歧义提示 `[config, context]`
  - `/s` -> 执行内置别名 `status`（别名匹配优先于前缀阶段的歧义匹配）
  - `/momory` -> 提示 `/memory`（拼写检查阶段）
  - `/how are you` -> 直接透传

### 2. 交互日志
- **歧义匹配拦截**:
  ```text
  命令不明确: /co
  可能想输入: /config /context
  发送 /help 查看全部命令。
  ```
- **错别字匹配拦截**:
  ```text
  未知命令: /momory
  你是不是想输入 /memory ?
  发送 /help 查看全部命令。
  ```

效果:
<img width="590" height="1055" alt="Screenshot 2026-05-30 at 23 01 55" src="https://github.com/user-attachments/assets/02f27a09-7551-4e41-b64d-346a04bc9c85" />

系统: Ubuntu

---

## 向后兼容性
- 完全保持对所有已有精确命令的调用机制一致性。
- `/momory` 等拼写检查逻辑与报错信息保持一致。
- **行为改变提示**：部分以前可能会直接透传给 LLM 的短指令（如 `/mem`, `/c`）现在会被拦截执行对应命令。