### PR TITLE
fix(mcp): replace select.select with queue.Queue for cross-platform stdio I/O

### DIFF
--- a/agent/tools/mcp/mcp_client.py
+++ b/agent/tools/mcp/mcp_client.py
@@ -59,7 +59,13 @@ class McpClient:
         # Shared state
         self._next_id = 1
         self._id_lock = threading.Lock()
+        # _call_lock serializes all requests on the single stdio pipe.
+        # SSE and streamable-http use independent HTTP requests, so they
+        # do not acquire this lock (see _send_request).
         self._call_lock = threading.Lock()
+        # _http_lock protects _http_session_id initialization across
+        # concurrent streamable-http requests.
+        self._http_lock = threading.Lock()
         self._initialized = False
 
     # ------------------------------------------------------------------
@@ -338,8 +344,12 @@ class McpClient:
             "Content-Type": "application/json",
             "Accept": "application/json, text/event-stream",
         }
-        if self._http_session_id:
-            headers["Mcp-Session-Id"] = self._http_session_id
+        # Read session id under lock to avoid racing with the
+        # initialization write below during concurrent requests.
+        with self._http_lock:
+            sid = self._http_session_id
+        if sid:
+            headers["Mcp-Session-Id"] = sid
         headers.update(self._http_headers)
 
         req = urllib.request.Request(
@@ -365,8 +375,13 @@ class McpClient:
         with resp:
             # Capture session id assigned by the server (if any)
             session_id = resp.headers.get("Mcp-Session-Id")
+            # Double-checked lock: only the first response sets the
+            # session id, preventing concurrent initializers from
+            # overwriting each other.
             if session_id and not self._http_session_id:
-                self._http_session_id = session_id
+                with self._http_lock:
+                    if not self._http_session_id:
+                        self._http_session_id = session_id
 
             status = resp.status if hasattr(resp, "status") else resp.getcode()
 
@@ -445,15 +460,18 @@ class McpClient:
 
         message = self._build_request(method, params)
 
-        with self._call_lock:
-            if self.transport == "stdio":
+        # stdio transport uses a single pipe and must be serialized.
+        # SSE and streamable-http use independent HTTP requests and
+        # can safely run concurrently across sessions.
+        if self.transport == "stdio":
+            with self._call_lock:
                 return self._stdio_send(message)
-            elif self.transport == "sse":
-                return self._sse_send(message)
-            elif self.transport == "streamable-http":
-                return self._streamable_http_send(message)
-            else:
-                raise ValueError(f"[MCP:{self.name}] Unsupported transport: {self.transport}")
+        elif self.transport == "sse":
+            return self._sse_send(message)
+        elif self.transport == "streamable-http":
+            return self._streamable_http_send(message)
+        else:
+            raise ValueError(f"[MCP:{self.name}] Unsupported transport: {self.transport}")
 
     def _send_notification(self, method: str, params: dict):
         """Fire-and-forget notification (no response expected)."""

--- a/agent/tools/mcp/mcp_client.py
+++ b/agent/tools/mcp/mcp_client.py
@@ -7,7 +7,7 @@ without any external MCP SDK dependency.
 
 import json
 import os
-import select
+import queue
 import subprocess
 import threading
 import urllib.request
@@ -34,6 +34,8 @@ class McpClient:
         self.config = config
         self.name: str = config.get("name", "unknown")
         raw_transport: str = config.get("type", "stdio")
+        # Per-server timeout for tool calls (default 120s, suitable for data queries)
+        self._timeout: int = int(config.get("timeout", 120))
         # Normalize streamable-http aliases to a single internal key
         self.transport: str = (
             "streamable-http"
@@ -43,6 +45,7 @@ class McpClient:
 
         # stdio state
         self._proc: Optional[subprocess.Popen] = None
+        self._read_queue: queue.Queue = queue.Queue()
 
         # SSE state
         self._sse_url: Optional[str] = None
@@ -172,6 +175,9 @@ class McpClient:
         threading.Thread(
             target=self._drain_stderr, daemon=True, name=f"mcp-stderr-{self.name}"
         ).start()
+        threading.Thread(
+            target=self._drain_stdout, daemon=True, name=f"mcp-stdout-{self.name}"
+        ).start()
 
         return self._handshake()
 
@@ -179,14 +185,35 @@ class McpClient:
         for line in self._proc.stderr:
             line = line.strip()
             if line:
-                logger.debug(f"[MCP:{self.name}] stderr: {line}")
+                logger.warning(f"[MCP:{self.name}] stderr: {line}")
 
-    def _readline_with_timeout(self, timeout: int = 30) -> str:
-        """Read one line from stdio stdout with a hard timeout."""
-        ready, _, _ = select.select([self._proc.stdout], [], [], timeout)
-        if not ready:
-            raise TimeoutError(f"[MCP:{self.name}] stdio read timed out after {timeout}s")
-        return self._proc.stdout.readline()
+    def _drain_stdout(self):
+        """Background thread: read lines from stdout and put them into the queue."""
+        try:
+            for line in self._proc.stdout:
+                self._read_queue.put(line)
+        except Exception:
+            pass
+        finally:
+            try:
+                self._read_queue.put("")
+            except Exception:
+                pass
+
+    def _readline_with_timeout(self, timeout: Optional[int] = None) -> str:
+        """Read one line from stdio stdout with a hard timeout (cross-platform).
+
+        Uses the per-server timeout from mcp.json config when no explicit
+        timeout is provided.
+        """
+        effective = timeout if timeout is not None else self._timeout
+        try:
+            line = self._read_queue.get(timeout=effective)
+        except queue.Empty:
+            raise TimeoutError(f"[MCP:{self.name}] stdio read timed out after {effective}s")
+        if not line:
+            raise IOError(f"[MCP:{self.name}] stdio process closed unexpectedly")
+        return line
 
     def _stdio_send(self, message: dict) -> dict:
         """Send a JSON-RPC message over stdio and read the response."""
@@ -194,6 +221,7 @@ class McpClient:
         self._proc.stdin.write(raw)
         self._proc.stdin.flush()
 
+        expected_id = message.get("id")
         while True:
             line = self._readline_with_timeout()
             if not line:
@@ -207,6 +235,14 @@ class McpClient:
                 continue
             if "id" not in data:
                 logger.debug(f"[MCP:{self.name}] notification skipped: {data.get('method', '?')}")
+                continue
+            # Verify response id matches request id to avoid consuming a stale
+            # response left over from a previously failed/timed-out request.
+            if data.get("id") != expected_id:
+                logger.warning(
+                    f"[MCP:{self.name}] Stale response id={data.get('id')} "
+                    f"(expected {expected_id}), skipping"
+                )
                 continue
             return data
 


### PR DESCRIPTION
  fix(mcp): replace select.select with queue.Queue for cross-platform stdio I/O

  - Use reader thread + queue.Queue instead of select.select() which does not work with pipes on Windows (only sockets)
  - Make MCP server timeout configurable via mcp.json (default 120s)
  - Validate JSON-RPC response id to skip stale responses from timed-out calls
  - Log MCP server stderr at WARNING level instead of DEBUG for visibility

  <!--
  Thanks for your contribution! Please write this PR in English.
  推荐使用英文填写，感谢 ❤️
  -->

  ## What does this PR do?

  On Windows, `select.select()` only works with sockets, not subprocess pipe file descriptors. This causes all stdio MCP servers to fail during initialization with "stdio read timed out after 30s". This PR replaces the `select.select()` call with a cross-platform   `queue.Queue` + daemon reader thread pattern that works on Windows, Linux, and macOS.
  It also adds configurable per-server timeout, response-id validation to prevent stale response consumption, and promotes MCP server
   stderr output from DEBUG to WARNING level for visibility.

  ## Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Docs
  - [x] Refactor / chore

  ## Checklist

  - [ ] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
  - [x] I tested this change locally
  - [x] Code comments and docs are in English
  - [ ] Linked related issue (if any): closes #
