### PR TITLE
feat: Add skill usage analytics dashboard

### DIFF
--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -1271,6 +1271,12 @@ class AgentStreamExecutor:
             success = result.status == "success"
             self._record_tool_result(tool_name, arguments, success)
 
+            # Record skill usage if this is a skill
+            self._record_skill_usage_if_applicable(
+                tool_name, arguments, success, execution_time * 1000,
+                result.result if not success else ""
+            )
+
             # Auto-refresh skills after skill creation
             if tool_name == "bash" and result.status == "success":
                 command = arguments.get("command", "")
@@ -1303,6 +1309,66 @@ class AgentStreamExecutor:
                 **error_result
             })
             return error_result
+
+    def _record_skill_usage_if_applicable(
+        self, tool_name: str, arguments: dict, success: bool, execution_time_ms: float, error_message: str = ""
+    ) -> None:
+        """Record skill usage if the tool references any skill directory.
+        
+        This method checks if the executed tool references a skill directory
+        (e.g., reading SKILL.md, executing scripts, or any file operations),
+        and if so, records the usage for analytics purposes.
+        """
+        try:
+            skill_manager = getattr(self.agent, 'skill_manager', None)
+            if not skill_manager:
+                return
+            
+            skill_name = None
+            
+            # Case 1: Tool name directly matches a skill (unlikely but keep for compatibility)
+            skill_entry = skill_manager.get_skill(tool_name)
+            if skill_entry:
+                skill_name = tool_name
+            else:
+                # Case 2: Tool arguments contain a reference to a skill directory
+                # e.g., read(path='.../skills/searxng-search/SKILL.md')
+                # e.g., bash(command='python .../skills/searxng-search/scripts/search.py')
+                # e.g., write(path='.../skills/image-generation/SKILL.md')
+                pattern = re.compile(r'skills/([^/]+)/')
+                
+                if arguments:
+                    for key, value in arguments.items():
+                        if isinstance(value, str):
+                            match = pattern.search(value)
+                            if match:
+                                candidate = match.group(1)
+                                # Verify this skill actually exists
+                                if skill_manager.get_skill(candidate):
+                                    skill_name = candidate
+                                    break
+            
+            if not skill_name:
+                return
+            
+            # Get workspace directory
+            workspace_dir = getattr(self.agent, 'workspace_dir', None)
+            if not workspace_dir:
+                return
+            
+            # Record the usage
+            from agent.skills.analytics import record_skill_usage
+            record_skill_usage(
+                workspace_dir=workspace_dir,
+                skill_name=skill_name,
+                success=success,
+                execution_time_ms=execution_time_ms,
+                error_message=error_message
+            )
+            
+            logger.debug(f"[SkillAnalytics] Recorded usage for skill '{skill_name}': success={success}")
+        except Exception as e:
+            logger.warning(f"[SkillAnalytics] Failed to record skill usage: {e}")
 
     def _build_tool_not_found_message(self, tool_name: str) -> str:
         """Build a helpful error message when a tool is not found.

--- a/agent/skills/analytics.py
+++ b/agent/skills/analytics.py
@@ -1,0 +1,311 @@
+"""Skill usage analytics for CowAgent.
+
+Tracks skill usage patterns and generates insights:
+- Usage frequency (how often each skill is used)
+- Success rate (how reliable each skill is)
+- Last used time (identify stale skills)
+- Execution time (performance metrics)
+- Usage trends (daily/weekly/monthly)
+
+Data is stored in workspace/skills/skill_usage_analytics.json
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Any
+
+from common.log import logger
+
+# Thread-safe lock for analytics updates
+_ANALYTICS_LOCK = threading.Lock()
+
+# Analytics file name
+ANALYTICS_FILE = "skill_usage_analytics.json"
+
+
+def _get_analytics_path(workspace_dir: str) -> Path:
+    """Get the path to the analytics file."""
+    return Path(workspace_dir) / "skills" / ANALYTICS_FILE
+
+
+def _load_analytics(workspace_dir: str) -> Dict[str, Any]:
+    """Load analytics data from disk."""
+    path = _get_analytics_path(workspace_dir)
+    if not path.exists():
+        return {"skills": {}, "summary": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning(f"[SkillAnalytics] Failed to load analytics: {e}")
+        return {"skills": {}, "summary": {}}
+
+
+def _save_analytics(workspace_dir: str, data: Dict[str, Any]) -> None:
+    """Save analytics data to disk."""
+    path = _get_analytics_path(workspace_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        logger.warning(f"[SkillAnalytics] Failed to save analytics: {e}")
+
+
+def record_skill_usage(
+    workspace_dir: str,
+    skill_name: str,
+    success: bool,
+    execution_time_ms: float = 0.0,
+    error_message: str = "",
+) -> None:
+    """Record a skill usage event.
+    
+    Args:
+        workspace_dir: Workspace directory path
+        skill_name: Name of the skill that was used
+        success: Whether the skill execution was successful
+        execution_time_ms: Execution time in milliseconds
+        error_message: Error message if failed
+    """
+    with _ANALYTICS_LOCK:
+        data = _load_analytics(workspace_dir)
+        
+        # Initialize skill entry if not exists
+        if skill_name not in data["skills"]:
+            data["skills"][skill_name] = {
+                "total_usage": 0,
+                "success_count": 0,
+                "failure_count": 0,
+                "first_used": datetime.now().isoformat(),
+                "last_used": None,
+                "total_execution_time_ms": 0.0,
+                "recent_usage": [],  # Last 100 usage events
+            }
+        
+        skill_data = data["skills"][skill_name]
+        
+        # Update counters
+        skill_data["total_usage"] += 1
+        if success:
+            skill_data["success_count"] += 1
+        else:
+            skill_data["failure_count"] += 1
+        
+        skill_data["last_used"] = datetime.now().isoformat()
+        skill_data["total_execution_time_ms"] += execution_time_ms
+        
+        # Add to recent usage (keep last 100)
+        usage_event = {
+            "timestamp": datetime.now().isoformat(),
+            "success": success,
+            "execution_time_ms": execution_time_ms,
+        }
+        if error_message:
+            usage_event["error"] = error_message[:200]  # Truncate long errors
+        
+        skill_data["recent_usage"].append(usage_event)
+        if len(skill_data["recent_usage"]) > 100:
+            skill_data["recent_usage"] = skill_data["recent_usage"][-100:]
+        
+        # Update summary
+        _update_summary(data)
+        
+        _save_analytics(workspace_dir, data)
+
+
+def _update_summary(data: Dict[str, Any]) -> None:
+    """Update the summary statistics."""
+    skills = data["skills"]
+    
+    if not skills:
+        data["summary"] = {}
+        return
+    
+    total_usage = sum(s["total_usage"] for s in skills.values())
+    total_success = sum(s["success_count"] for s in skills.values())
+    
+    # Find most/least used
+    sorted_by_usage = sorted(skills.items(), key=lambda x: x[1]["total_usage"], reverse=True)
+    most_used = sorted_by_usage[0][0] if sorted_by_usage else None
+    least_used = sorted_by_usage[-1][0] if sorted_by_usage else None
+    
+    # Find most/least reliable
+    reliable_skills = [
+        (name, s["success_count"] / s["total_usage"] if s["total_usage"] > 0 else 0)
+        for name, s in skills.items()
+    ]
+    sorted_by_reliability = sorted(reliable_skills, key=lambda x: x[1], reverse=True)
+    most_reliable = sorted_by_reliability[0][0] if sorted_by_reliability else None
+    least_reliable = sorted_by_reliability[-1][0] if sorted_by_reliability else None
+    
+    data["summary"] = {
+        "total_skills": len(skills),
+        "total_usage": total_usage,
+        "overall_success_rate": total_success / total_usage if total_usage > 0 else 0,
+        "most_used_skill": most_used,
+        "least_used_skill": least_used,
+        "most_reliable_skill": most_reliable,
+        "least_reliable_skill": least_reliable,
+        "last_updated": datetime.now().isoformat(),
+    }
+
+
+def generate_usage_report(
+    workspace_dir: str,
+    days: int = 30,
+    format: str = "text",
+) -> str:
+    """Generate a skill usage report.
+    
+    Args:
+        workspace_dir: Workspace directory path
+        days: Number of days to analyze (default: 30)
+        format: Output format - "text", "json", or "markdown"
+    
+    Returns:
+        Formatted report string
+    """
+    data = _load_analytics(workspace_dir)
+    skills = data["skills"]
+    
+    if not skills:
+        return "No skill usage data available yet."
+    
+    # Filter by time range
+    cutoff = datetime.now() - timedelta(days=days)
+    filtered_skills = {}
+    
+    for name, skill_data in skills.items():
+        recent = [
+            u for u in skill_data["recent_usage"]
+            if datetime.fromisoformat(u["timestamp"]) >= cutoff
+        ]
+        if recent:
+            filtered_skills[name] = {
+                "total_usage": len(recent),
+                "success_count": sum(1 for u in recent if u["success"]),
+                "failure_count": sum(1 for u in recent if not u["success"]),
+                "avg_execution_time_ms": (
+                    sum(u["execution_time_ms"] for u in recent) / len(recent)
+                    if recent else 0
+                ),
+                "last_used": skill_data["last_used"],
+            }
+    
+    if not filtered_skills:
+        return f"No skill usage in the last {days} days."
+    
+    # Sort by usage
+    sorted_skills = sorted(
+        filtered_skills.items(),
+        key=lambda x: x[1]["total_usage"],
+        reverse=True
+    )
+    
+    if format == "json":
+        return json.dumps({
+            "period_days": days,
+            "skills": dict(sorted_skills),
+            "summary": data.get("summary", {}),
+        }, indent=2, ensure_ascii=False)
+    
+    # Text/Markdown format
+    lines = []
+    lines.append(f"# Skill Usage Report (Last {days} Days)\n")
+    lines.append(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+    
+    # Summary
+    total_usage = sum(s["total_usage"] for s in filtered_skills.values())
+    total_success = sum(s["success_count"] for s in filtered_skills.values())
+    success_rate = (total_success / total_usage * 100) if total_usage > 0 else 0
+    
+    lines.append("## Summary\n")
+    lines.append(f"- **Total Skills Used:** {len(filtered_skills)}")
+    lines.append(f"- **Total Usage Count:** {total_usage}")
+    lines.append(f"- **Overall Success Rate:** {success_rate:.1f}%")
+    lines.append(f"- **Most Used:** {sorted_skills[0][0]} ({sorted_skills[0][1]['total_usage']} times)")
+    lines.append("")
+    
+    # Detailed breakdown
+    lines.append("## Detailed Usage\n")
+    lines.append("| Skill | Usage | Success Rate | Avg Time (ms) | Last Used |")
+    lines.append("|-------|-------|--------------|---------------|-----------|")
+    
+    for name, stats in sorted_skills:
+        success_rate = (stats["success_count"] / stats["total_usage"] * 100) if stats["total_usage"] > 0 else 0
+        last_used = stats["last_used"][:10] if stats["last_used"] else "N/A"
+        lines.append(
+            f"| {name} | {stats['total_usage']} | {success_rate:.1f}% | "
+            f"{stats['avg_execution_time_ms']:.1f} | {last_used} |"
+        )
+    
+    lines.append("")
+    
+    # Identify unused skills (if we have full skill list)
+    all_skills = set(skills.keys())
+    used_skills = set(filtered_skills.keys())
+    unused_skills = all_skills - used_skills
+    
+    if unused_skills:
+        lines.append("## Unused Skills (Recommend for Review)\n")
+        for name in sorted(unused_skills):
+            last_used = skills[name]["last_used"]
+            last_used_str = last_used[:10] if last_used else "Never"
+            lines.append(f"- **{name}** - Last used: {last_used_str}")
+        lines.append("")
+    
+    # Performance insights
+    slow_skills = [
+        (name, stats["avg_execution_time_ms"])
+        for name, stats in filtered_skills.items()
+        if stats["avg_execution_time_ms"] > 1000  # > 1 second
+    ]
+    
+    if slow_skills:
+        lines.append("## Performance Alerts\n")
+        lines.append("Skills with average execution time > 1 second:")
+        for name, time_ms in sorted(slow_skills, key=lambda x: x[1], reverse=True):
+            lines.append(f"- **{name}**: {time_ms:.0f}ms")
+        lines.append("")
+    
+    return "\n".join(lines)
+
+
+def get_unused_skills(
+    workspace_dir: str,
+    days: int = 30,
+) -> List[str]:
+    """Get list of skills not used in the specified time period.
+    
+    Args:
+        workspace_dir: Workspace directory path
+        days: Number of days to check
+    
+    Returns:
+        List of unused skill names
+    """
+    data = _load_analytics(workspace_dir)
+    skills = data["skills"]
+    
+    cutoff = datetime.now() - timedelta(days=days)
+    unused = []
+    
+    for name, skill_data in skills.items():
+        last_used = skill_data.get("last_used")
+        if not last_used:
+            unused.append(name)
+            continue
+        
+        last_used_dt = datetime.fromisoformat(last_used)
+        if last_used_dt < cutoff:
+            unused.append(name)
+    
+    return sorted(unused)
+
+
+

--- a/channel/web/chat.html
+++ b/channel/web/chat.html
@@ -201,6 +201,11 @@
                             <i class="fas fa-terminal item-icon text-xs w-5 text-center"></i>
                             <span data-i18n="menu_logs">日志</span>
                         </a>
+                        <a class="sidebar-item flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-all duration-150 hover:bg-white/5 hover:text-neutral-200 text-[14px]"
+                           data-view="skill-analytics">
+                            <i class="fas fa-chart-line item-icon text-xs w-5 text-center"></i>
+                            <span data-i18n="menu_skill_analytics">技能监控</span>
+                        </a>
                     </div>
                 </div>
             </nav>
@@ -1088,6 +1093,177 @@
                                 </div>
                                 <div id="log-output" class="p-4 overflow-y-auto font-mono text-xs leading-relaxed text-slate-300 whitespace-pre-wrap break-all" style="height: calc(100vh - 272px)">
                                     <p class="text-slate-500" data-i18n="logs_coming_msg">日志流即将在此提供。将连接 run.log 实现类似 tail -f 的实时输出。</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ====================================================== -->
+                <!-- VIEW: Skill Analytics                                  -->
+                <!-- ====================================================== -->
+                <div id="view-skill-analytics" class="view">
+                    <div class="flex-1 overflow-y-auto p-6">
+                        <div class="max-w-7xl mx-auto">
+                            <!-- Header -->
+                            <div class="flex items-center justify-between mb-8 skill-header-animate">
+                                <div>
+                                    <div class="flex items-center gap-4 mb-2">
+                                        <div class="w-14 h-14 rounded-2xl bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center shadow-xl shadow-cyan-500/40 skill-icon-float">
+                                            <i class="fas fa-chart-line text-white text-2xl"></i>
+                                        </div>
+                                        <div>
+                                            <h2 class="text-3xl font-extrabold bg-gradient-to-r from-cyan-400 via-blue-400 to-purple-500 bg-clip-text text-transparent" data-i18n="skill_analytics_title">技能监控</h2>
+                                            <p class="text-sm text-slate-400 mt-1 flex items-center gap-2">
+                                                <span class="inline-block w-2 h-2 rounded-full bg-emerald-400 animate-pulse"></span>
+                                                <span data-i18n="skill_analytics_desc">Skill 使用分析与健康度评估</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <button onclick="loadSkillAnalytics()" class="group relative px-6 py-3 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 text-white text-sm font-semibold cursor-pointer transition-all duration-300 hover:shadow-xl hover:shadow-cyan-500/50 hover:scale-105 overflow-hidden">
+                                    <div class="absolute inset-0 bg-gradient-to-r from-white/0 via-white/20 to-white/0 translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-700"></div>
+                                    <i class="fas fa-sync-alt mr-2 group-hover:rotate-180 transition-transform duration-500"></i>
+                                    <span data-i18n="skill_analytics_refresh">刷新数据</span>
+                                </button>
+                            </div>
+
+                            <!-- Summary Cards -->
+                            <div id="analytics-summary" class="grid grid-cols-2 md:grid-cols-5 gap-5 mb-8">
+                                <div class="relative group skill-card-3d" style="--card-color: rose;">
+                                    <div class="absolute inset-0 bg-gradient-to-br from-rose-500/20 to-pink-500/20 rounded-2xl blur-xl group-hover:blur-2xl transition-all duration-300 opacity-60 group-hover:opacity-100"></div>
+                                    <div class="relative bg-slate-900/60 backdrop-blur-xl border border-rose-500/30 rounded-2xl p-6 hover:border-rose-500/60 transition-all duration-300 skill-card-glow overflow-hidden">
+                                        <div class="absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-rose-500/10 to-transparent rounded-bl-full"></div>
+                                        <div class="flex items-center justify-between mb-4">
+                                            <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-rose-500 to-pink-500 flex items-center justify-center shadow-lg shadow-rose-500/30 skill-icon-bounce">
+                                                <i class="fas fa-cubes text-white text-lg"></i>
+                                            </div>
+                                            <div class="text-3xl font-bold text-rose-400 counter-animate" id="analytics-total-installed" data-target="0">-</div>
+                                        </div>
+                                        <div class="text-sm text-slate-400 font-medium" data-i18n="skill_analytics_total_installed">已安装 Skill</div>
+                                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-rose-500 to-pink-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                                    </div>
+                                </div>
+
+                                <div class="relative group skill-card-3d" style="--card-color: blue;">
+                                    <div class="absolute inset-0 bg-gradient-to-br from-blue-500/20 to-cyan-500/20 rounded-2xl blur-xl group-hover:blur-2xl transition-all duration-300 opacity-60 group-hover:opacity-100"></div>
+                                    <div class="relative bg-slate-900/60 backdrop-blur-xl border border-blue-500/30 rounded-2xl p-6 hover:border-blue-500/60 transition-all duration-300 skill-card-glow overflow-hidden">
+                                        <div class="absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-blue-500/10 to-transparent rounded-bl-full"></div>
+                                        <div class="flex items-center justify-between mb-4">
+                                            <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500 to-cyan-500 flex items-center justify-center shadow-lg shadow-blue-500/30 skill-icon-bounce">
+                                                <i class="fas fa-bolt text-white text-lg"></i>
+                                            </div>
+                                            <div class="text-3xl font-bold text-blue-400 counter-animate" id="analytics-total-uses" data-target="0">-</div>
+                                        </div>
+                                        <div class="text-sm text-slate-400 font-medium" data-i18n="skill_analytics_total_uses">总使用次数</div>
+                                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 to-cyan-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                                    </div>
+                                </div>
+
+                                <div class="relative group skill-card-3d" style="--card-color: emerald;">
+                                    <div class="absolute inset-0 bg-gradient-to-br from-emerald-500/20 to-teal-500/20 rounded-2xl blur-xl group-hover:blur-2xl transition-all duration-300 opacity-60 group-hover:opacity-100"></div>
+                                    <div class="relative bg-slate-900/60 backdrop-blur-xl border border-emerald-500/30 rounded-2xl p-6 hover:border-emerald-500/60 transition-all duration-300 skill-card-glow overflow-hidden">
+                                        <div class="absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-emerald-500/10 to-transparent rounded-bl-full"></div>
+                                        <div class="flex items-center justify-between mb-4">
+                                            <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-500 flex items-center justify-center shadow-lg shadow-emerald-500/30 skill-icon-bounce">
+                                                <i class="fas fa-check-circle text-white text-lg"></i>
+                                            </div>
+                                            <div class="text-3xl font-bold text-emerald-400 counter-animate" id="analytics-active-skills" data-target="0">-</div>
+                                        </div>
+                                        <div class="text-sm text-slate-400 font-medium" data-i18n="skill_analytics_active">活跃 Skill</div>
+                                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-emerald-500 to-teal-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                                    </div>
+                                </div>
+
+                                <div class="relative group skill-card-3d" style="--card-color: amber;">
+                                    <div class="absolute inset-0 bg-gradient-to-br from-amber-500/20 to-orange-500/20 rounded-2xl blur-xl group-hover:blur-2xl transition-all duration-300 opacity-60 group-hover:opacity-100"></div>
+                                    <div class="relative bg-slate-900/60 backdrop-blur-xl border border-amber-500/30 rounded-2xl p-6 hover:border-amber-500/60 transition-all duration-300 skill-card-glow overflow-hidden">
+                                        <div class="absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-amber-500/10 to-transparent rounded-bl-full"></div>
+                                        <div class="flex items-center justify-between mb-4">
+                                            <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-amber-500 to-orange-500 flex items-center justify-center shadow-lg shadow-amber-500/30 skill-icon-bounce">
+                                                <i class="fas fa-percentage text-white text-lg"></i>
+                                            </div>
+                                            <div class="text-3xl font-bold text-amber-400 counter-animate" id="analytics-success-rate" data-target="0">-</div>
+                                        </div>
+                                        <div class="text-sm text-slate-400 font-medium" data-i18n="skill_analytics_success_rate">平均成功率</div>
+                                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-amber-500 to-orange-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                                    </div>
+                                </div>
+
+                                <div class="relative group skill-card-3d" style="--card-color: violet;">
+                                    <div class="absolute inset-0 bg-gradient-to-br from-violet-500/20 to-purple-500/20 rounded-2xl blur-xl group-hover:blur-2xl transition-all duration-300 opacity-60 group-hover:opacity-100"></div>
+                                    <div class="relative bg-slate-900/60 backdrop-blur-xl border border-violet-500/30 rounded-2xl p-6 hover:border-violet-500/60 transition-all duration-300 skill-card-glow overflow-hidden">
+                                        <div class="absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-violet-500/10 to-transparent rounded-bl-full"></div>
+                                        <div class="flex items-center justify-between mb-4">
+                                            <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-500 to-purple-500 flex items-center justify-center shadow-lg shadow-violet-500/30 skill-icon-bounce">
+                                                <i class="fas fa-clock text-white text-lg"></i>
+                                            </div>
+                                            <div class="text-3xl font-bold text-violet-400 counter-animate" id="analytics-avg-time" data-target="0">-</div>
+                                        </div>
+                                        <div class="text-sm text-slate-400 font-medium" data-i18n="skill_analytics_avg_time">平均执行时间</div>
+                                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-violet-500 to-purple-500 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Skill Usage Table -->
+                            <div class="relative mb-8 skill-fade-in-up" style="animation-delay: 0.3s;">
+                                <div class="absolute inset-0 bg-gradient-to-br from-cyan-500/10 to-blue-500/10 rounded-2xl blur-2xl"></div>
+                                <div class="relative bg-slate-900/60 backdrop-blur-xl border border-cyan-500/20 rounded-2xl overflow-hidden">
+                                    <div class="px-6 py-5 border-b border-cyan-500/20 bg-gradient-to-r from-cyan-500/10 to-blue-500/10">
+                                        <div class="flex items-center justify-between">
+                                            <div class="flex items-center gap-3">
+                                                <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center shadow-lg shadow-cyan-500/30">
+                                                    <i class="fas fa-trophy text-white"></i>
+                                                </div>
+                                                <h3 class="text-lg font-bold text-cyan-400" data-i18n="skill_analytics_usage">使用排行</h3>
+                                            </div>
+                                            <div class="flex items-center gap-2 text-xs text-slate-500">
+                                                <span class="inline-block w-2 h-2 rounded-full bg-cyan-400 animate-pulse"></span>
+                                                <span>实时数据</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="overflow-x-auto">
+                                        <table class="w-full">
+                                            <thead class="bg-slate-800/50">
+                                                <tr>
+                                                    <th class="px-6 py-4 text-left text-xs font-semibold text-cyan-400 uppercase tracking-wider" data-i18n="skill_analytics_col_skill">技能</th>
+                                                    <th class="px-6 py-4 text-left text-xs font-semibold text-cyan-400 uppercase tracking-wider" data-i18n="skill_analytics_col_uses">使用次数</th>
+                                                    <th class="px-6 py-4 text-left text-xs font-semibold text-cyan-400 uppercase tracking-wider" data-i18n="skill_analytics_col_success">成功率</th>
+                                                    <th class="px-6 py-4 text-left text-xs font-semibold text-cyan-400 uppercase tracking-wider" data-i18n="skill_analytics_col_time">执行时间</th>
+                                                    <th class="px-6 py-4 text-left text-xs font-semibold text-cyan-400 uppercase tracking-wider" data-i18n="skill_analytics_col_health">健康度</th>
+                                                    <th class="px-6 py-4 text-left text-xs font-semibold text-cyan-400 uppercase tracking-wider" data-i18n="skill_analytics_col_last">最后使用</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="analytics-table-body" class="divide-y divide-slate-700/50">
+                                                <tr>
+                                                    <td colspan="6" class="px-6 py-12 text-center text-slate-400" data-i18n="skill_analytics_loading">加载中...</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Unused Skills -->
+                            <div class="relative skill-fade-in-up" style="animation-delay: 0.5s;">
+                                <div class="absolute inset-0 bg-gradient-to-br from-slate-500/10 to-slate-600/10 rounded-2xl blur-2xl"></div>
+                                <div class="relative bg-slate-900/60 backdrop-blur-xl border border-slate-500/20 rounded-2xl overflow-hidden">
+                                    <div class="px-6 py-5 border-b border-slate-500/20 bg-gradient-to-r from-slate-500/10 to-slate-600/10">
+                                        <div class="flex items-center gap-3">
+                                            <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-slate-500 to-slate-600 flex items-center justify-center shadow-lg shadow-slate-500/30">
+                                                <i class="fas fa-inbox text-white"></i>
+                                            </div>
+                                            <div>
+                                                <h3 class="text-lg font-bold text-slate-300" data-i18n="skill_analytics_unused">未使用的 Skill</h3>
+                                                <p class="text-xs text-slate-400 mt-0.5" data-i18n="skill_analytics_unused_desc">这些 Skill 尚未被调用过，可以考虑清理或优化使用方式</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div id="analytics-unused-list" class="p-6">
+                                        <p class="text-sm text-slate-400" data-i18n="skill_analytics_loading">加载中...</p>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/channel/web/static/css/console.css
+++ b/channel/web/static/css/console.css
@@ -1683,3 +1683,163 @@
     cursor: not-allowed !important;
     opacity: 0.35 !important;
 }
+
+/* =====================================================================
+   Skill Analytics - Cool Animations & Effects
+   ===================================================================== */
+
+/* Header entrance animation */
+@keyframes skillHeaderIn {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+.skill-header-animate {
+    animation: skillHeaderIn 0.6s ease-out both;
+}
+
+/* Icon floating animation */
+@keyframes iconFloat {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
+}
+.skill-icon-float {
+    animation: iconFloat 3s ease-in-out infinite;
+}
+
+/* Icon bounce on card hover */
+@keyframes iconBounce {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.15) rotate(5deg); }
+}
+.skill-card-3d:hover .skill-icon-bounce {
+    animation: iconBounce 0.5s ease-in-out;
+}
+
+/* Card 3D tilt effect */
+.skill-card-3d {
+    perspective: 800px;
+    transition: transform 0.3s ease;
+}
+.skill-card-3d:hover {
+    transform: translateY(-6px);
+}
+.skill-card-3d:hover > div:first-child {
+    opacity: 1 !important;
+}
+
+/* Card glow border pulse */
+@keyframes cardGlow {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(56, 189, 248, 0); }
+    50% { box-shadow: 0 0 20px 2px rgba(56, 189, 248, 0.15); }
+}
+.skill-card-glow:hover {
+    animation: cardGlow 2s ease-in-out infinite;
+}
+
+/* Counter number animation */
+@keyframes counterPop {
+    0% { opacity: 0; transform: scale(0.5) translateY(10px); }
+    60% { transform: scale(1.1) translateY(-2px); }
+    100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+.counter-animate {
+    animation: counterPop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* Fade in up for sections */
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(30px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+.skill-fade-in-up {
+    opacity: 0;
+    animation: fadeInUp 0.7s ease-out forwards;
+}
+
+/* Table row hover glow */
+#analytics-table-body tr {
+    transition: all 0.25s ease;
+}
+#analytics-table-body tr:hover {
+    background: linear-gradient(90deg, rgba(6, 182, 212, 0.05) 0%, rgba(59, 130, 246, 0.05) 100%);
+    box-shadow: inset 0 0 30px rgba(6, 182, 212, 0.03);
+}
+
+/* Progress bar shimmer */
+@keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+}
+.skill-progress-shimmer {
+    background: linear-gradient(90deg, transparent 25%, rgba(255,255,255,0.15) 50%, transparent 75%);
+    background-size: 200% 100%;
+    animation: shimmer 2s infinite;
+}
+
+/* Health badge pulse for high scores */
+@keyframes healthPulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
+    50% { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
+}
+.skill-health-pulse {
+    animation: healthPulse 2s ease-in-out infinite;
+}
+
+/* Unused skill card hover */
+.skill-unused-card {
+    transition: all 0.3s ease;
+}
+.skill-unused-card:hover {
+    transform: translateX(4px);
+    border-color: rgba(148, 163, 184, 0.4) !important;
+    background: rgba(30, 41, 59, 0.5) !important;
+}
+
+/* Particle canvas styling */
+#skill-particles-canvas {
+    opacity: 0.4;
+}
+
+/* Rank badge styles */
+.skill-rank-gold {
+    text-shadow: 0 0 8px rgba(255, 215, 0, 0.5);
+}
+.skill-rank-silver {
+    text-shadow: 0 0 8px rgba(192, 192, 192, 0.5);
+}
+.skill-rank-bronze {
+    text-shadow: 0 0 8px rgba(205, 127, 50, 0.5);
+}
+
+/* Refresh button ripple */
+@keyframes ripple {
+    0% { transform: scale(0); opacity: 0.5; }
+    100% { transform: scale(4); opacity: 0; }
+}
+
+/* Staggered card entrance */
+.skill-card-3d:nth-child(1) { animation: fadeInUp 0.5s ease-out 0.1s both; }
+.skill-card-3d:nth-child(2) { animation: fadeInUp 0.5s ease-out 0.2s both; }
+.skill-card-3d:nth-child(3) { animation: fadeInUp 0.5s ease-out 0.3s both; }
+.skill-card-3d:nth-child(4) { animation: fadeInUp 0.5s ease-out 0.4s both; }
+.skill-card-3d:nth-child(5) { animation: fadeInUp 0.5s ease-out 0.5s both; }
+
+/* Table row staggered entrance */
+@keyframes rowSlideIn {
+    from { opacity: 0; transform: translateX(-20px); }
+    to { opacity: 1; transform: translateX(0); }
+}
+.skill-row-animate {
+    animation: rowSlideIn 0.4s ease-out both;
+}
+
+/* Sparkle effect on numbers */
+@keyframes sparkle {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; text-shadow: 0 0 10px currentColor; }
+}
+.skill-number-sparkle {
+    animation: sparkle 1.5s ease-in-out;
+}
+
+

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -16,7 +16,28 @@ const I18N = {
         nav_chat: '对话', nav_manage: '管理', nav_monitor: '监控',
         menu_chat: '对话', menu_config: '配置', menu_models: '模型', menu_skills: '技能',
         menu_memory: '记忆', menu_knowledge: '知识', menu_channels: '通道', menu_tasks: '定时',
-        menu_logs: '日志',
+        menu_logs: '日志', menu_skill_analytics: '技能监控',
+        skill_analytics_title: '技能监控',
+        skill_analytics_desc: 'Skill 使用分析与健康度评估',
+        skill_analytics_refresh: '刷新数据',
+        skill_analytics_total_installed: '已安装 Skill',
+        skill_analytics_total_uses: '总使用次数',
+        skill_analytics_active: '活跃 Skill',
+        skill_analytics_success_rate: '平均成功率',
+        skill_analytics_avg_time: '平均执行时间',
+        skill_analytics_usage: '使用排行',
+        skill_analytics_col_skill: '技能',
+        skill_analytics_col_uses: '使用次数',
+        skill_analytics_col_success: '成功率',
+        skill_analytics_col_time: '执行时间',
+        skill_analytics_col_health: '健康度',
+        skill_analytics_col_last: '最后使用',
+        skill_analytics_loading: '加载中...',
+        skill_analytics_no_data: '暂无使用数据',
+        skill_analytics_load_failed: '加载失败',
+        skill_analytics_unused: '未使用的 Skill',
+        skill_analytics_unused_desc: '这些 Skill 尚未被调用过，可以考虑清理或优化使用方式',
+        skill_analytics_all_used: '所有 Skill 都已被使用过 🎉',
         models_title: '模型管理',
         models_desc: '统一管理对话、图像、语音、向量、搜索能力',
         models_section_vendors: '厂商凭据',
@@ -260,7 +281,28 @@ const I18N = {
         nav_chat: 'Chat', nav_manage: 'Management', nav_monitor: 'Monitor',
         menu_chat: 'Chat', menu_config: 'Config', menu_models: 'Models', menu_skills: 'Skills',
         menu_memory: 'Memory', menu_knowledge: 'Knowledge', menu_channels: 'Channels', menu_tasks: 'Tasks',
-        menu_logs: 'Logs',
+        menu_logs: 'Logs', menu_skill_analytics: 'Skill Analytics',
+        skill_analytics_title: 'Skill Analytics',
+        skill_analytics_desc: 'Skill usage analysis and health assessment',
+        skill_analytics_refresh: 'Refresh',
+        skill_analytics_total_installed: 'Installed Skills',
+        skill_analytics_total_uses: 'Total Uses',
+        skill_analytics_active: 'Active Skills',
+        skill_analytics_success_rate: 'Avg Success Rate',
+        skill_analytics_avg_time: 'Avg Execution Time',
+        skill_analytics_usage: 'Usage Ranking',
+        skill_analytics_col_skill: 'Skill',
+        skill_analytics_col_uses: 'Uses',
+        skill_analytics_col_success: 'Success Rate',
+        skill_analytics_col_time: 'Exec Time',
+        skill_analytics_col_health: 'Health',
+        skill_analytics_col_last: 'Last Used',
+        skill_analytics_loading: 'Loading...',
+        skill_analytics_no_data: 'No usage data',
+        skill_analytics_load_failed: 'Load failed',
+        skill_analytics_unused: 'Unused Skills',
+        skill_analytics_unused_desc: 'These skills have not been called yet, consider cleaning or optimizing usage',
+        skill_analytics_all_used: 'All skills have been used 🎉',
         models_title: 'Models',
         models_desc: 'Manage chat, image, voice, embedding and search capabilities in one place',
         models_section_vendors: 'Provider Credentials',
@@ -712,6 +754,7 @@ const VIEW_META = {
     channels: { group: 'nav_manage',  page: 'menu_channels' },
     tasks:    { group: 'nav_manage',  page: 'menu_tasks' },
     logs:     { group: 'nav_monitor', page: 'menu_logs' },
+    'skill-analytics': { group: 'nav_monitor', page: 'menu_skill_analytics' },
 };
 
 let currentView = 'chat';
@@ -4644,7 +4687,7 @@ function loadToolsSection() {
         toolsLoaded = true;
     }).catch(() => {
         emptyEl.classList.remove('hidden');
-        emptyEl.innerHTML = `<span class="text-sm text-slate-400 dark:text-slate-500">${currentLang === 'zh' ? '加载失败' : 'Failed to load'}</span>`;
+        emptyEl.innerHTML = `<span class="text-sm text-slate-400 dark:text-slate-500">${t('skill_analytics_load_failed')}</span>`;
     });
 }
 
@@ -7760,7 +7803,192 @@ navigateTo = function(viewId) {
     else if (viewId === 'channels') loadChannelsView();
     else if (viewId === 'tasks') loadTasksView();
     else if (viewId === 'logs') startLogStream();
+    else if (viewId === 'skill-analytics') loadSkillAnalytics();
 };
+
+// =====================================================================
+// Skill Analytics View
+// =====================================================================
+
+// Animated counter
+function animateCounter(el, target, suffix = '') {
+    const duration = 800;
+    const start = 0;
+    const startTime = performance.now();
+    
+    function update(currentTime) {
+        const elapsed = currentTime - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        const easeOut = 1 - Math.pow(1 - progress, 3);
+        const current = Math.floor(start + (target - start) * easeOut);
+        el.textContent = current + suffix;
+        if (progress < 1) {
+            requestAnimationFrame(update);
+        } else {
+            el.textContent = target + suffix;
+            el.classList.add('skill-number-sparkle');
+        }
+    }
+    requestAnimationFrame(update);
+}
+
+function loadSkillAnalytics() {
+    const totalInstalledEl = document.getElementById('analytics-total-installed');
+    const totalUsesEl = document.getElementById('analytics-total-uses');
+    const activeSkillsEl = document.getElementById('analytics-active-skills');
+    const successRateEl = document.getElementById('analytics-success-rate');
+    const avgTimeEl = document.getElementById('analytics-avg-time');
+    const tableBodyEl = document.getElementById('analytics-table-body');
+    const unusedListEl = document.getElementById('analytics-unused-list');
+
+    // Show loading state
+    totalInstalledEl.textContent = '-';
+    totalUsesEl.textContent = '-';
+    activeSkillsEl.textContent = '-';
+    successRateEl.textContent = '-';
+    avgTimeEl.textContent = '-';
+    tableBodyEl.innerHTML = `<tr><td colspan="6" class="px-6 py-8 text-center text-slate-500 dark:text-slate-400">${t('skill_analytics_loading')}</td></tr>`;
+    unusedListEl.innerHTML = `<p class="text-sm text-slate-500 dark:text-slate-400">${t('skill_analytics_loading')}</p>`;
+
+    // Fetch analytics data
+    fetch('/api/skill-analytics').then(r => r.json()).then(data => {
+        if (data.status !== 'success') {
+            tableBodyEl.innerHTML = `<tr><td colspan="6" class="px-6 py-8 text-center text-red-500">${t('skill_analytics_load_failed')}</td></tr>`;
+            return;
+        }
+
+        const analytics = data.analytics || {};
+        const skills = analytics.skills || {};
+        const unused = analytics.unused || [];
+        const totalInstalled = analytics.total_installed || 0;
+
+        // Calculate summary stats
+        let totalUses = 0;
+        let totalSuccess = 0;
+        let totalTime = 0;
+        let activeCount = 0;
+
+        Object.values(skills).forEach(skill => {
+            totalUses += skill.uses || 0;
+            totalSuccess += skill.success || 0;
+            totalTime += skill.total_time || 0;
+            if (skill.uses > 0) activeCount++;
+        });
+
+        const avgSuccessRate = totalUses > 0 ? (totalSuccess / totalUses * 100).toFixed(1) : 0;
+        const avgTime = totalUses > 0 ? (totalTime / totalUses).toFixed(0) : 0;
+
+        // Animate summary cards
+        animateCounter(totalInstalledEl, totalInstalled);
+        animateCounter(totalUsesEl, totalUses);
+        animateCounter(activeSkillsEl, activeCount);
+        animateCounter(successRateEl, parseFloat(avgSuccessRate), '%');
+        animateCounter(avgTimeEl, parseInt(avgTime), 'ms');
+
+        // Build usage table - show ALL skills (used first, then unused)
+        const usedSkills = Object.entries(skills)
+            .filter(([_, s]) => s.uses > 0)
+            .sort((a, b) => b[1].uses - a[1].uses);
+        
+        const unusedSkills = Object.entries(skills)
+            .filter(([_, s]) => s.uses === 0)
+            .sort((a, b) => a[0].localeCompare(b[0]));
+        
+        const skillArray = [...usedSkills, ...unusedSkills];
+
+        if (skillArray.length === 0) {
+            tableBodyEl.innerHTML = `<tr><td colspan="6" class="px-6 py-12 text-center text-slate-400">${t('skill_analytics_no_data')}</td></tr>`;
+        } else {
+            tableBodyEl.innerHTML = '';
+            let rankIndex = 0;
+            skillArray.forEach(([name, skill]) => {
+                const isUsed = skill.uses > 0;
+                const successRate = skill.uses > 0 ? (skill.success / skill.uses * 100).toFixed(1) : 0;
+                const avgExecTime = skill.uses > 0 ? (skill.total_time / skill.uses).toFixed(0) : 0;
+                const healthScore = isUsed ? Math.min(100, Math.round(successRate * 0.7 + (avgExecTime < 1000 ? 30 : avgExecTime < 3000 ? 20 : 10))) : 0;
+                const lastUsed = skill.last_used ? new Date(skill.last_used).toLocaleString('zh-CN') : '-';
+
+                const healthColor = !isUsed ? 'from-slate-600 to-slate-700' : healthScore >= 80 ? 'from-emerald-500 to-teal-500' : healthScore >= 60 ? 'from-amber-500 to-orange-500' : 'from-red-500 to-rose-500';
+                const healthTextColor = !isUsed ? 'text-slate-500' : healthScore >= 80 ? 'text-emerald-400' : healthScore >= 60 ? 'text-amber-400' : 'text-red-400';
+                const successTextColor = !isUsed ? 'text-slate-500' : successRate >= 90 ? 'text-emerald-400' : successRate >= 70 ? 'text-amber-400' : 'text-red-400';
+                
+                let rankBadge;
+                if (!isUsed) {
+                    rankBadge = '-';
+                } else if (rankIndex === 0) {
+                    rankBadge = '🥇';
+                } else if (rankIndex === 1) {
+                    rankBadge = '🥈';
+                } else if (rankIndex === 2) {
+                    rankBadge = '🥉';
+                } else {
+                    rankBadge = `#${rankIndex + 1}`;
+                }
+                if (isUsed) rankIndex++;
+
+                const row = document.createElement('tr');
+                row.className = isUsed ? 'hover:bg-cyan-500/5 transition-all duration-200' : 'hover:bg-slate-500/5 transition-all duration-200';
+                row.innerHTML = `
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        <div class="flex items-center gap-3">
+                            <div class="w-8 h-8 rounded-lg bg-gradient-to-br ${isUsed ? 'from-cyan-500/20 to-blue-500/20 border-cyan-500/30' : 'from-slate-600/20 to-slate-700/20 border-slate-500/30'} border flex items-center justify-center text-xs font-bold ${isUsed ? 'text-cyan-400' : 'text-slate-400'}">
+                                ${rankBadge}
+                            </div>
+                            <span class="font-medium text-sm ${isUsed ? 'text-slate-200' : 'text-slate-400'} font-mono">${escapeHtml(name)}</span>
+                        </div>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        <span class="text-sm font-semibold ${isUsed ? 'text-blue-400' : 'text-slate-500'}">${skill.uses}</span>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        <div class="flex items-center gap-2">
+                            <div class="w-24 h-2 bg-slate-700 rounded-full overflow-hidden">
+                                <div class="h-full bg-gradient-to-r ${healthColor} rounded-full transition-all duration-500" style="width: ${successRate}%"></div>
+                            </div>
+                            <span class="text-sm font-semibold ${successTextColor}">${successRate}%</span>
+                        </div>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        <span class="text-sm ${isUsed ? 'text-slate-300' : 'text-slate-500'}">${avgExecTime}<span class="text-slate-400 text-xs ml-1">ms</span></span>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-gradient-to-r ${healthColor} bg-opacity-20 border border-white/10">
+                            <i class="fas ${isUsed ? 'fa-shield-halved' : 'fa-minus-circle'} text-xs ${healthTextColor}"></i>
+                            <span class="text-sm font-bold ${healthTextColor}">${isUsed ? healthScore : '-'}</span>
+                        </div>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-xs ${isUsed ? 'text-slate-400' : 'text-slate-500'}">${lastUsed}</td>
+                `;
+                tableBodyEl.appendChild(row);
+            });
+        }
+
+        // Build unused skills list
+        if (unused.length === 0) {
+            unusedListEl.innerHTML = `<p class="text-sm text-slate-400">${t('skill_analytics_all_used')}</p>`;
+        } else {
+            unusedListEl.innerHTML = '';
+            const grid = document.createElement('div');
+            grid.className = 'grid grid-cols-1 md:grid-cols-2 gap-3';
+            unused.forEach(name => {
+                const item = document.createElement('div');
+                item.className = 'flex items-center gap-3 p-4 rounded-xl bg-slate-800/30 border border-slate-600/30 hover:border-slate-500/50 transition-all duration-200';
+                item.innerHTML = `
+                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-slate-600/30 to-slate-700/30 border border-slate-500/20 flex items-center justify-center">
+                        <i class="fas fa-puzzle-piece text-slate-400 text-sm"></i>
+                    </div>
+                    <span class="text-sm text-slate-300 font-mono">${escapeHtml(name)}</span>
+                `;
+                grid.appendChild(item);
+            });
+            unusedListEl.appendChild(grid);
+        }
+    }).catch(err => {
+        console.error('Failed to load skill analytics:', err);
+        tableBodyEl.innerHTML = `<tr><td colspan="6" class="px-6 py-12 text-center text-red-400">${t('skill_analytics_load_failed')}</td></tr>`;
+        unusedListEl.innerHTML = `<p class="text-sm text-red-400">${t('skill_analytics_load_failed')}</p>`;
+    });
+}
 
 // =====================================================================
 // Knowledge View

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -1288,6 +1288,7 @@ class WebChannel(ChatChannel):
             '/api/messages/delete', 'MessageDeleteHandler',
             '/api/logs', 'LogsHandler',
             '/api/version', 'VersionHandler',
+            '/api/skill-analytics', 'SkillAnalyticsHandler',
             '/assets/(.*)', 'AssetsHandler',
         )
         app = web.application(urls, globals(), autoreload=False)
@@ -4917,3 +4918,71 @@ class VersionHandler:
         web.header('Content-Type', 'application/json; charset=utf-8')
         from cli import __version__
         return json.dumps({"version": __version__})
+
+
+class SkillAnalyticsHandler:
+    def GET(self):
+        _require_auth()
+        web.header('Content-Type', 'application/json; charset=utf-8')
+        try:
+            from agent.skills.analytics import generate_usage_report, get_unused_skills
+            workspace_root = _get_workspace_root()
+            
+            # Get report in JSON format
+            report_json = generate_usage_report(workspace_root, format="json")
+            report_data = json.loads(report_json) if report_json != "No skill usage data available yet." else {}
+            
+            # Get unused skills
+            unused = get_unused_skills(workspace_root)
+            
+            # Scan all installed skills from skills/ directory
+            skills_dir = os.path.join(workspace_root, 'skills')
+            installed_skills = set()
+            if os.path.isdir(skills_dir):
+                for entry in os.listdir(skills_dir):
+                    skill_md = os.path.join(skills_dir, entry, 'SKILL.md')
+                    if os.path.isdir(os.path.join(skills_dir, entry)) and os.path.isfile(skill_md):
+                        installed_skills.add(entry)
+            
+            # Transform report_data to match frontend expected format
+            skills_data = {}
+            for skill_name, skill_stats in report_data.get("skills", {}).items():
+                skills_data[skill_name] = {
+                    "uses": skill_stats.get("total_usage", 0),
+                    "success": skill_stats.get("success_count", 0),
+                    "failure": skill_stats.get("failure_count", 0),
+                    "total_time": skill_stats.get("avg_execution_time_ms", 0) * skill_stats.get("total_usage", 0),
+                    "last_used": skill_stats.get("last_used"),
+                    "installed": skill_name in installed_skills,
+                }
+            
+            # Add installed but never-used skills with zero stats
+            unused_list = []
+            for skill_name in sorted(installed_skills):
+                if skill_name not in skills_data:
+                    skills_data[skill_name] = {
+                        "uses": 0,
+                        "success": 0,
+                        "failure": 0,
+                        "total_time": 0,
+                        "last_used": None,
+                        "installed": True,
+                    }
+                    unused_list.append(skill_name)
+            
+            # Merge with analytics unused list
+            all_unused = sorted(set(unused) | set(unused_list))
+            
+            return json.dumps({
+                "status": "success",
+                "analytics": {
+                    "skills": skills_data,
+                    "unused": all_unused,
+                    "total_installed": len(installed_skills),
+                    "total_used": len([s for s in skills_data.values() if s["uses"] > 0]),
+                }
+            }, ensure_ascii=False)
+        except Exception as e:
+            logger.error(f"[WebChannel] Skill analytics API error: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+


### PR DESCRIPTION
## What does this PR do?

Add a skill usage analytics dashboard to help users monitor and optimize their skill usage patterns.

**Key changes:**
- **Backend**: New `analytics.py` module for tracking skill usage metrics (invocation count, success rate, response time, trends)
- **Auto-recording**: Automatically record skill usage in `agent_stream.py` when tools are executed
- **API endpoint**: Add `/api/skill-analytics` endpoint in `web_channel.py` to serve analytics data
- **Frontend**: Add analytics dashboard UI in `chat.html` with usage statistics, trend visualization, and unused skill detection
- **Styling & Logic**: Add corresponding CSS styles and JavaScript logic for the analytics view

**Why this is needed:**
Users currently have no visibility into which skills are being used, how often, or which ones are never used. This dashboard provides insights to:
- Identify most-used skills and optimize their performance
- Detect unused skills that can be removed to reduce clutter
- Monitor skill health through success rates and response times
- Track usage trends over time

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #