### PR TITLE
feat(agent): add multi-agent workspace registry

### DIFF
--- a/agent/registry.py
+++ b/agent/registry.py
@@ -1,0 +1,238 @@
+"""Agent profile registry.
+
+The registry is deliberately small: an agent is identified by a stable ID and
+one complete CowAgent workspace. Runtime, routing, and persistence layers build
+on this module without changing the existing single-agent configuration path.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from common.utils import expand_path
+
+
+_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class AgentRegistryError(ValueError):
+    """Raised when agent configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    """Configuration for one complete CowAgent workspace."""
+
+    id: str
+    name: str
+    workspace: str
+    enabled: bool = True
+    model: Optional[str] = None
+    bot_type: Optional[str] = None
+
+    @property
+    def workspace_path(self) -> Path:
+        return Path(self.workspace)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "workspace": self.workspace,
+            "enabled": self.enabled,
+        }
+        if self.model:
+            data["model"] = self.model
+        if self.bot_type:
+            data["bot_type"] = self.bot_type
+        return data
+
+
+def _normalise_workspace(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AgentRegistryError("agent workspace must be a non-empty string")
+    return str(Path(expand_path(value.strip())).resolve(strict=False))
+
+
+def _profile_from_mapping(raw: Mapping[str, Any]) -> AgentProfile:
+    agent_id = raw.get("id")
+    if not isinstance(agent_id, str) or not _AGENT_ID_RE.fullmatch(agent_id):
+        raise AgentRegistryError(
+            "agent id must be 1-64 URL-safe characters: letters, numbers, _ or -"
+        )
+
+    name = raw.get("name", agent_id)
+    if not isinstance(name, str) or not name.strip():
+        raise AgentRegistryError(f"agent '{agent_id}' name must be a non-empty string")
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise AgentRegistryError(f"agent '{agent_id}' enabled must be a boolean")
+
+    model = raw.get("model")
+    bot_type = raw.get("bot_type")
+    for key, value in (("model", model), ("bot_type", bot_type)):
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise AgentRegistryError(
+                f"agent '{agent_id}' {key} must be a non-empty string when set"
+            )
+
+    return AgentProfile(
+        id=agent_id,
+        name=name.strip(),
+        workspace=_normalise_workspace(raw.get("workspace")),
+        enabled=enabled,
+        model=model.strip() if isinstance(model, str) else None,
+        bot_type=bot_type.strip() if isinstance(bot_type, str) else None,
+    )
+
+
+class AgentRegistry:
+    """Thread-safe registry of configured agent workspaces."""
+
+    def __init__(self, profiles: Iterable[AgentProfile], default_agent_id: str):
+        self._lock = threading.RLock()
+        self._profiles: Dict[str, AgentProfile] = {}
+        self._default_agent_id = default_agent_id
+
+        workspaces: Dict[str, str] = {}
+        for profile in profiles:
+            if profile.id in self._profiles:
+                raise AgentRegistryError(f"duplicate agent id: {profile.id}")
+            owner = workspaces.get(profile.workspace)
+            if owner is not None:
+                raise AgentRegistryError(
+                    f"agents '{owner}' and '{profile.id}' share workspace "
+                    f"'{profile.workspace}'"
+                )
+            self._profiles[profile.id] = profile
+            workspaces[profile.workspace] = profile.id
+
+        if not self._profiles:
+            raise AgentRegistryError("at least one agent profile is required")
+        self._validate_default(default_agent_id)
+
+    @classmethod
+    def from_config(cls, settings: Mapping[str, Any]) -> "AgentRegistry":
+        raw_agents = settings.get("agents")
+        if raw_agents is None or raw_agents == []:
+            workspace = settings.get("agent_workspace", "~/cow")
+            profile = AgentProfile(
+                id="default",
+                name="Default",
+                workspace=_normalise_workspace(workspace),
+            )
+            return cls([profile], "default")
+
+        if not isinstance(raw_agents, list):
+            raise AgentRegistryError("agents must be a list")
+        profiles: List[AgentProfile] = []
+        for index, raw in enumerate(raw_agents):
+            if not isinstance(raw, Mapping):
+                raise AgentRegistryError(f"agents[{index}] must be an object")
+            profiles.append(_profile_from_mapping(raw))
+
+        default_agent_id = settings.get("default_agent_id", "default")
+        if not isinstance(default_agent_id, str) or not default_agent_id:
+            raise AgentRegistryError("default_agent_id must be a non-empty string")
+        return cls(profiles, default_agent_id)
+
+    @property
+    def default_agent_id(self) -> str:
+        with self._lock:
+            return self._default_agent_id
+
+    def _validate_default(self, agent_id: str) -> None:
+        profile = self._profiles.get(agent_id)
+        if profile is None:
+            raise AgentRegistryError(f"default agent '{agent_id}' is not configured")
+        if not profile.enabled:
+            raise AgentRegistryError(f"default agent '{agent_id}' is disabled")
+
+    def get(self, agent_id: Optional[str] = None, require_enabled: bool = True) -> AgentProfile:
+        with self._lock:
+            resolved_id = agent_id or self._default_agent_id
+            profile = self._profiles.get(resolved_id)
+            if profile is None:
+                raise KeyError(resolved_id)
+            if require_enabled and not profile.enabled:
+                raise AgentRegistryError(f"agent '{resolved_id}' is disabled")
+            return profile
+
+    def get_or_default(self, agent_id: Optional[str]) -> AgentProfile:
+        with self._lock:
+            profile = self._profiles.get(agent_id) if agent_id else None
+            if profile is not None and profile.enabled:
+                return profile
+            return self._profiles[self._default_agent_id]
+
+    def list(self, include_disabled: bool = True) -> List[AgentProfile]:
+        with self._lock:
+            profiles = list(self._profiles.values())
+            if not include_disabled:
+                profiles = [profile for profile in profiles if profile.enabled]
+            return sorted(profiles, key=lambda profile: profile.id)
+
+    def upsert(self, profile: AgentProfile) -> None:
+        with self._lock:
+            for existing in self._profiles.values():
+                if existing.id != profile.id and existing.workspace == profile.workspace:
+                    raise AgentRegistryError(
+                        f"agents '{existing.id}' and '{profile.id}' share workspace "
+                        f"'{profile.workspace}'"
+                    )
+            self._profiles[profile.id] = profile
+            self._validate_default(self._default_agent_id)
+
+    def set_enabled(self, agent_id: str, enabled: bool) -> AgentProfile:
+        with self._lock:
+            current = self.get(agent_id, require_enabled=False)
+            if agent_id == self._default_agent_id and not enabled:
+                raise AgentRegistryError("the default agent cannot be disabled")
+            updated = replace(current, enabled=enabled)
+            self._profiles[agent_id] = updated
+            return updated
+
+    def set_default(self, agent_id: str) -> None:
+        with self._lock:
+            profile = self.get(agent_id, require_enabled=True)
+            self._default_agent_id = profile.id
+
+    def remove(self, agent_id: str) -> AgentProfile:
+        with self._lock:
+            if agent_id == self._default_agent_id:
+                raise AgentRegistryError("the default agent cannot be removed")
+            try:
+                return self._profiles.pop(agent_id)
+            except KeyError:
+                raise KeyError(agent_id) from None
+
+
+_registry_instance: Optional[AgentRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_agent_registry() -> AgentRegistry:
+    """Return the process-wide registry built from the current configuration."""
+
+    global _registry_instance
+    if _registry_instance is not None:
+        return _registry_instance
+    with _registry_lock:
+        if _registry_instance is None:
+            from config import conf
+
+            _registry_instance = AgentRegistry.from_config(conf())
+        return _registry_instance
+
+
+def set_agent_registry(registry: Optional[AgentRegistry]) -> None:
+    """Replace the process registry, primarily for config reloads and tests."""
+
+    global _registry_instance
+    with _registry_lock:
+        _registry_instance = registry

--- a/config.py
+++ b/config.py
@@ -257,6 +257,12 @@ available_setting = {
     "mcp_oauth_redirect_base": "",  # Base URL for MCP OAuth callback (e.g. http://your-ip:9899); empty uses local web console
     "agent": True,  # whether to enable Agent mode
     "agent_workspace": "~/cow",  # agent workspace path, used to store skills, memory, etc.
+    # Optional native multi-agent registry. When empty or omitted, CowAgent
+    # synthesizes one "default" agent from agent_workspace and behaves exactly
+    # as before. Each configured workspace is a complete CowAgent workspace.
+    "agents": [],
+    "default_agent_id": "default",
+    "agent_bindings": [],
     "agent_max_context_tokens": 50000,  # max context tokens in Agent mode
     "agent_max_context_turns": 20,  # max context memory turns in Agent mode
     "agent_max_steps": 20,  # max decision steps per run in Agent mode

--- a/docs/superpowers/plans/2026-07-19-native-multi-agent-implementation.md
+++ b/docs/superpowers/plans/2026-07-19-native-multi-agent-implementation.md
@@ -1,0 +1,86 @@
+# Native Multi-Agent Implementation Plan
+
+## Change 1: Agent registry
+
+- Add immutable `AgentProfile` values and a thread-safe `AgentRegistry`.
+- Parse `agents`, `default_agent_id`, and `agent_bindings` from configuration.
+- Synthesize the default profile from `agent_workspace` when the new fields are
+  absent.
+- Validate IDs, duplicate workspaces, enabled defaults, and binding targets.
+- Add unit tests for compatibility and invalid configurations.
+
+Verification: registry tests, configuration tests, Python compilation.
+
+## Change 2: Runtime isolation
+
+- Thread `agent_id` through `AgentBridge`, `AgentInitializer`, and chat service.
+- Key live agent instances by `(agent_id, session_id)`.
+- Pass the resolved workspace explicitly to prompt, tools, skills, memory, and
+  runtime metadata.
+- Add eviction helpers for one agent and one agent session.
+- Test same-session isolation and legacy callers.
+
+Verification: bridge/initializer tests and existing agent tests.
+
+## Change 3: Workspace-scoped state
+
+- Replace memory and conversation process singletons with workspace registries.
+- Replace scheduler singleton access with workspace-scoped services and stores.
+- Scope flush, Deep Dream, evolution, session operations, and task execution to
+  the owning workspace.
+- Keep the existing database schema and file layout.
+- Test independent databases, tasks, timers, and cleanup.
+
+Verification: memory, conversation, scheduler, evolution, and regression tests.
+
+## Change 4: Routing
+
+- Add a binding resolver with exact, channel-default, and global-default
+  precedence.
+- Add `agent_id` to inbound contexts and preserve it through queues, replies,
+  persistence, and cancellation.
+- Add Web chat agent selection.
+- Test private chats, groups, missing targets, disabled targets, and unchanged
+  default routing.
+
+Verification: routing and representative channel tests.
+
+## Change 5: Web management
+
+- Add authenticated APIs for agent CRUD, bindings, and allowed core files.
+- Use atomic writes, path containment checks, and content revisions.
+- Add an Agents page and selectors in chat, sessions, tasks, memory, skills, and
+  knowledge views where relevant.
+- Evict only the affected agent after core-file changes.
+- Test API authorization, validation, traversal protection, conflicts, and UI
+  production build.
+
+Verification: API tests, TypeScript checks, and desktop production build.
+
+## Change 6: Delegation
+
+- Add a delegation service and `agent_delegate` tool.
+- Create stable target relay sessions without user-channel delivery.
+- Enforce target policy, timeout, cancellation, depth, cycle, size, and
+  concurrency limits.
+- Return structured provenance and errors.
+- Test success, unavailable targets, timeout, cancellation, and cycles.
+
+Verification: delegation tests and agent tool regressions.
+
+## Change 7: Backup and hardening
+
+- Extend the backup manifest with registry, bindings, and selected workspaces.
+- Preserve archive traversal, destination, and rollback protections.
+- Add single-agent and all-agent backup/restore tests.
+- Update English, Chinese, and Japanese documentation.
+- Run the complete Python suite and desktop build against the final stack.
+
+Verification: backup tests, full Python suite, desktop build, and diff checks.
+
+## Publication
+
+- Preserve one branch pointer after each ordered change.
+- Push all implementation branches only after the final stack passes.
+- Open reviewable pull requests with explicit dependency notes and validation.
+- Open one tracking issue describing the completed work and merge order.

--- a/docs/superpowers/specs/2026-07-19-native-multi-agent-design.md
+++ b/docs/superpowers/specs/2026-07-19-native-multi-agent-design.md
@@ -1,0 +1,155 @@
+# Native Multi-Agent Workspaces
+
+## Goal
+
+Allow one CowAgent process to host multiple agents without changing the
+behaviour of existing single-agent installations. Each agent is a complete
+CowAgent workspace, not a lightweight persona overlay.
+
+## Workspace model
+
+An agent profile identifies one workspace root. The existing workspace layout
+is reused unchanged:
+
+```text
+<workspace>/
+├── AGENT.md
+├── USER.md
+├── RULE.md
+├── MEMORY.md
+├── memory/
+├── skills/
+├── knowledge/
+├── output/
+└── scheduler/
+```
+
+The workspace owns the agent's persona, user profile, rules, long-term memory,
+daily memory, search index, conversation history, skills, knowledge, scheduler
+tasks, evolution data, and generated output.
+
+There is no second home directory abstraction. There is also no shared memory
+database with an `agent_id` column. Each workspace keeps using its own
+`memory/long-term/index.db`, matching the current single-agent layout.
+
+## Configuration
+
+The optional configuration is:
+
+```json
+{
+  "default_agent_id": "default",
+  "agents": [
+    {
+      "id": "default",
+      "name": "Default",
+      "workspace": "~/cow",
+      "enabled": true
+    }
+  ],
+  "agent_bindings": []
+}
+```
+
+When `agents` is absent, CowAgent synthesizes one `default` profile from the
+existing `agent_workspace` value. Existing configuration and data therefore
+continue to work without a migration.
+
+Agent IDs are stable, URL-safe identifiers. Workspace paths must be unique.
+Agent deletion is represented as disabling or archiving the profile; workspace
+data is never deleted implicitly.
+
+## Runtime isolation
+
+The runtime key becomes `(agent_id, session_id)`. Initializing an agent resolves
+the profile first, then passes its workspace explicitly through prompt loading,
+memory, tools, skills, scheduler, and persistence.
+
+Process-wide state that currently binds to the first workspace is replaced by
+workspace-keyed registries:
+
+```text
+workspace → MemoryManager
+workspace → ConversationStore
+workspace → SchedulerService / TaskStore
+workspace → memory flush, Deep Dream, and evolution runtime
+```
+
+No agent may obtain a manager, store, or scheduler belonging to another
+workspace, even when both sessions use the same external session identifier.
+
+## Routing
+
+Inbound contexts carry `agent_id`. Resolution follows a deterministic order:
+
+1. exact channel and conversation binding;
+2. channel-level default binding;
+3. configured `default_agent_id`.
+
+Bindings that reference a missing or disabled agent fall back to the default
+agent and emit a warning. Existing channels require no binding and continue to
+use the default agent.
+
+## Web console
+
+The console can list, create, clone, enable, disable, and select agents. It can
+edit the four core files `AGENT.md`, `USER.md`, `RULE.md`, and `MEMORY.md`.
+
+The editor is intentionally not a general filesystem browser. The backend uses
+an allowlist, resolves paths beneath the selected workspace, writes atomically,
+and rejects stale writes using a content revision. Updating a core file evicts
+only that agent's live sessions so its next turn rebuilds the prompt.
+
+New profiles use the existing workspace bootstrap and templates. A new agent
+therefore has the same onboarding and capabilities as the original single
+agent.
+
+## Inter-agent delegation
+
+Agents communicate through a guarded request-response tool:
+
+```text
+agent_delegate(target_agent, message, timeout_seconds)
+```
+
+The target runs in its own workspace and a dedicated relay session. Results
+include source attribution and structured errors. The runtime enforces target
+allowlists, timeouts, cancellation, message limits, maximum delegation depth,
+and cycle detection. Delegated output is returned to the caller and is not sent
+to a user channel automatically.
+
+## Backup and restore
+
+Backups include the registry, bindings, and selected agent workspaces. Restore
+validates manifest versions, profile IDs, workspace destinations, and archive
+paths before writing. Restores remain transactional and preserve the existing
+rollback behaviour.
+
+No import tooling is part of this design.
+
+## Delivery
+
+The work is split into seven ordered changes:
+
+1. agent registry and compatibility configuration;
+2. agent-aware runtime initialization;
+3. workspace-scoped memory, sessions, and scheduler;
+4. channel bindings and routing;
+5. Web console management and core-file editor;
+6. guarded inter-agent delegation;
+7. multi-agent backup, documentation, and final hardening.
+
+Later changes depend on earlier ones. Each change must include its own tests and
+preserve the zero-configuration single-agent path.
+
+## Acceptance criteria
+
+- Existing configurations still use `~/cow` exactly as before.
+- Two agents with the same session ID cannot share runtime state or data.
+- Memory, conversation history, scheduled tasks, skills, and knowledge remain
+  inside the selected workspace.
+- Channel bindings resolve deterministically and fail safely.
+- The console can create an agent and safely edit its four core Markdown files.
+- Delegation cannot recurse forever or bypass disabled-target checks.
+- Backup and restore preserve all configured agents without writing outside
+  approved workspace paths.

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+import pytest
+
+from agent.registry import AgentProfile, AgentRegistry, AgentRegistryError
+
+
+def test_legacy_config_synthesizes_default_agent(tmp_path):
+    workspace = tmp_path / "cow"
+    registry = AgentRegistry.from_config({"agent_workspace": str(workspace)})
+
+    profile = registry.get()
+    assert profile.id == "default"
+    assert profile.name == "Default"
+    assert profile.workspace_path == workspace.resolve()
+    assert registry.default_agent_id == "default"
+
+
+def test_configured_agents_keep_separate_workspaces(tmp_path):
+    registry = AgentRegistry.from_config(
+        {
+            "default_agent_id": "writer",
+            "agents": [
+                {"id": "writer", "name": "Writer", "workspace": str(tmp_path / "writer")},
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "workspace": str(tmp_path / "research"),
+                    "model": "gpt-5",
+                    "bot_type": "openai",
+                },
+            ],
+        }
+    )
+
+    assert registry.get().id == "writer"
+    assert registry.get("research").model == "gpt-5"
+    assert registry.get("research").bot_type == "openai"
+    assert [profile.id for profile in registry.list()] == ["research", "writer"]
+
+
+@pytest.mark.parametrize("agent_id", ["", "has space", "/root", "x" * 65])
+def test_invalid_agent_ids_are_rejected(tmp_path, agent_id):
+    with pytest.raises(AgentRegistryError, match="agent id"):
+        AgentRegistry.from_config(
+            {"agents": [{"id": agent_id, "workspace": str(tmp_path / "one")}]}
+        )
+
+
+def test_duplicate_ids_and_workspaces_are_rejected(tmp_path):
+    with pytest.raises(AgentRegistryError, match="duplicate agent id"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "one")},
+                    {"id": "one", "workspace": str(tmp_path / "two")},
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+    with pytest.raises(AgentRegistryError, match="share workspace"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "shared")},
+                    {"id": "two", "workspace": str(tmp_path / "shared")},
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+
+def test_default_agent_must_exist_and_be_enabled(tmp_path):
+    with pytest.raises(AgentRegistryError, match="not configured"):
+        AgentRegistry.from_config(
+            {
+                "agents": [{"id": "one", "workspace": str(tmp_path / "one")}],
+                "default_agent_id": "missing",
+            }
+        )
+
+    with pytest.raises(AgentRegistryError, match="disabled"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "one"), "enabled": False}
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+
+def test_registry_mutations_preserve_default_invariants(tmp_path):
+    registry = AgentRegistry.from_config({"agent_workspace": str(tmp_path / "default")})
+    second = AgentProfile(
+        id="second",
+        name="Second",
+        workspace=str((tmp_path / "second").resolve()),
+    )
+    registry.upsert(second)
+
+    registry.set_default("second")
+    registry.set_enabled("default", False)
+    assert registry.get().id == "second"
+    assert registry.get_or_default("default").id == "second"
+
+    with pytest.raises(AgentRegistryError, match="default agent cannot be disabled"):
+        registry.set_enabled("second", False)
+    with pytest.raises(AgentRegistryError, match="default agent cannot be removed"):
+        registry.remove("second")
+
+    removed = registry.remove("default")
+    assert removed.id == "default"
+    assert [profile.id for profile in registry.list()] == ["second"]
+
+
+def test_profile_to_dict_omits_empty_overrides(tmp_path):
+    profile = AgentProfile(
+        id="default",
+        name="Default",
+        workspace=str(Path(tmp_path).resolve()),
+    )
+    assert profile.to_dict() == {
+        "id": "default",
+        "name": "Default",
+        "workspace": str(Path(tmp_path).resolve()),
+        "enabled": True,
+    }


### PR DESCRIPTION
## Summary

- add a validated Agent registry with stable IDs and one workspace per Agent
- preserve the current `agent_workspace` path by synthesizing a compatible default profile when `agents` is absent
- support enabled state plus optional per-Agent model and provider fields
- reject malformed IDs, duplicate workspaces, and invalid defaults before startup

This is the first PR in the native multi-Agent series and is intentionally limited to configuration and registry behavior.

## Compatibility

Existing single-Agent configuration does not need to change. With no `agents` list, runtime behavior and the workspace path remain unchanged.

## Test

```bash
python -m pytest -q tests/test_agent_registry.py
```
