### PR TITLE
feat(agent): isolate runtime by agent workspace

### DIFF
--- a/agent/chat/service.py
+++ b/agent/chat/service.py
@@ -27,8 +27,14 @@ class ChatService:
         """
         self.agent_bridge = agent_bridge
 
-    def run(self, query: str, session_id: str, send_chunk_fn: Callable[[dict], None],
-            channel_type: str = ""):
+    def run(
+        self,
+        query: str,
+        session_id: str,
+        send_chunk_fn: Callable[[dict], None],
+        channel_type: str = "",
+        agent_id: str = None,
+    ):
         """
         Run the agent for *query* and stream results back via *send_chunk_fn*.
 
@@ -39,8 +45,12 @@ class ChatService:
         :param session_id: session identifier for agent isolation
         :param send_chunk_fn: callable(chunk_data: dict) to send a streaming chunk
         :param channel_type: source channel (e.g. "web", "feishu") for persistence
+        :param agent_id: selected agent profile; defaults to the configured default
         """
-        agent = self.agent_bridge.get_agent(session_id=session_id)
+        resolved_agent_id = self.agent_bridge._resolve_agent_id(agent_id)
+        agent = self.agent_bridge.get_agent(
+            session_id=session_id, agent_id=resolved_agent_id
+        )
         if agent is None:
             raise RuntimeError("Failed to initialise agent for the session")
 
@@ -48,11 +58,14 @@ class ChatService:
         if hasattr(agent, 'model'):
             agent.model.channel_type = channel_type or ""
             agent.model.session_id = session_id or ""
+            agent.model.agent_id = resolved_agent_id
 
         # Build a context so context-aware tools (e.g. scheduler) can resolve the
         # receiver/session. This streaming path bypasses agent_bridge.agent_reply,
         # so the attach step that normally happens there must be done here too.
-        context = self._build_context(query, session_id, channel_type)
+        context = self._build_context(
+            query, session_id, channel_type, resolved_agent_id
+        )
         self._attach_context_aware_tools(agent, context)
 
         # Mark this session as mid-run so the self-evolution idle scan does not
@@ -166,7 +179,10 @@ class ChatService:
                     state.segment_id += 1
 
         # Run the agent with our event callback ---------------------------
-        logger.info(f"[ChatService] Starting agent run: session={session_id}, query={query[:80]}")
+        logger.info(
+            f"[ChatService] Starting agent run: agent={resolved_agent_id}, "
+            f"session={session_id}, query={query[:80]}"
+        )
 
         from config import conf
         max_context_turns = conf().get("agent_max_context_turns", 20)
@@ -185,7 +201,16 @@ class ChatService:
         # IM channels key on session_id (no per-turn request_id here).
         from agent.protocol import get_cancel_registry
         registry = get_cancel_registry()
-        cancel_event = registry.register(session_id, session_id=session_id) if session_id else None
+        cancel_key = (
+            self.agent_bridge._cancel_key(
+                resolved_agent_id,
+                session_id,
+                self.agent_bridge.agent_registry.default_agent_id,
+            )
+            if session_id
+            else None
+        )
+        cancel_event = registry.register(cancel_key, session_id=session_id) if cancel_key else None
 
         executor = AgentStreamExecutor(
             agent=agent,
@@ -214,7 +239,7 @@ class ChatService:
             # Release cancel token to keep the registry bounded.
             if session_id:
                 try:
-                    registry.unregister(session_id)
+                    registry.unregister(cancel_key)
                 except Exception:
                     pass
 
@@ -285,12 +310,17 @@ class ChatService:
         # be noted here, otherwise idle scans never see any signal to evolve.
         self._note_evolution_turn(agent, context)
 
-        logger.info(f"[ChatService] Agent run completed: session={session_id}")
+        logger.info(
+            f"[ChatService] Agent run completed: agent={resolved_agent_id}, "
+            f"session={session_id}"
+        )
 
 
 
     @staticmethod
-    def _build_context(query: str, session_id: str, channel_type: str):
+    def _build_context(
+        query: str, session_id: str, channel_type: str, agent_id: str = "default"
+    ):
         """Build a Context for tool resolution on the streaming chat path.
 
         receiver falls back to session_id; the scheduler's delivery keys on
@@ -304,6 +334,7 @@ class ChatService:
         ctx["receiver"] = session_id
         ctx["isgroup"] = False
         ctx["channel_type"] = channel_type or ""
+        ctx["agent_id"] = agent_id
         return ctx
 
     @staticmethod

--- a/agent/chat/session_service.py
+++ b/agent/chat/session_service.py
@@ -94,9 +94,7 @@ class SessionService:
         try:
             from bridge.bridge import Bridge
             ab = Bridge().get_agent_bridge()
-            if session_id in ab.agents:
-                del ab.agents[session_id]
-                logger.info(f"[SessionService] Removed agent instance: {session_id}")
+            ab.clear_session(session_id)
         except Exception:
             pass
 

--- a/agent/evolution/executor.py
+++ b/agent/evolution/executor.py
@@ -303,6 +303,7 @@ def _workspace_changed(workspace_dir, pre: dict) -> bool:
 def run_evolution_for_session(
     agent_bridge,
     session_id: str,
+    agent_id: str = "default",
     channel_type: str = "",
     receiver: str = "",
     user_id: Optional[str] = None,
@@ -329,7 +330,10 @@ def run_evolution_for_session(
         _running_count += 1
 
     try:
-        agent = agent_bridge.agents.get(session_id) or agent_bridge.default_agent
+        if hasattr(agent_bridge, "get_cached_agent"):
+            agent = agent_bridge.get_cached_agent(session_id, agent_id=agent_id)
+        else:
+            agent = agent_bridge.agents.get(session_id) or agent_bridge.default_agent
         if not agent:
             return False
 
@@ -359,8 +363,10 @@ def run_evolution_for_session(
         )
 
         # Resolve workspace + files to snapshot for undo.
-        from agent.memory.config import get_default_memory_config
-        mem_cfg = get_default_memory_config()
+        mem_cfg = getattr(getattr(agent, "memory_manager", None), "config", None)
+        if mem_cfg is None:
+            from agent.memory.config import get_default_memory_config
+            mem_cfg = get_default_memory_config()
         workspace_dir = mem_cfg.get_workspace()
         if user_id:
             memory_file = Path(workspace_dir) / "memory" / "users" / user_id / "MEMORY.md"
@@ -509,12 +515,15 @@ def _inject_evolution_record(
             note += f"\n(backup_id: {backup_id}; to undo, restore this backup)"
         # Reuse the scheduler-output injection path: isolated execution, only a
         # compact record lands in the user session.
-        agent_bridge.remember_scheduled_output(
-            session_id=session_id,
-            content=note,
-            channel_type=channel_type,
-            task_description="self-evolution",
-        )
+        remember_kwargs = {
+            "session_id": session_id,
+            "content": note,
+            "channel_type": channel_type,
+            "task_description": "self-evolution",
+        }
+        if hasattr(agent_bridge, "agent_registry"):
+            remember_kwargs["agent_id"] = agent_id
+        agent_bridge.remember_scheduled_output(**remember_kwargs)
     except Exception as e:
         logger.debug(f"[Evolution] Failed to inject evolution record: {e}")
 

--- a/agent/evolution/trigger.py
+++ b/agent/evolution/trigger.py
@@ -116,8 +116,14 @@ def _scan_loop(agent_bridge) -> None:
 def _scan_once(agent_bridge, cfg) -> None:
     now = time.time()
     # Snapshot to avoid holding the dict while running long evolutions.
-    sessions = list(getattr(agent_bridge, "agents", {}).items())
-    for session_id, agent in sessions:
+    if hasattr(agent_bridge, "iter_agent_instances"):
+        sessions = list(agent_bridge.iter_agent_instances(include_defaults=False))
+    else:
+        sessions = [
+            ("default", session_id, agent)
+            for session_id, agent in getattr(agent_bridge, "agents", {}).items()
+        ]
+    for agent_id, session_id, agent in sessions:
         try:
             # Skip sessions whose agent is mid-run: a long turn must not be
             # reviewed while it is still producing the answer.
@@ -143,6 +149,7 @@ def _scan_once(agent_bridge, cfg) -> None:
             run_evolution_for_session(
                 agent_bridge,
                 session_id=session_id,
+                agent_id=agent_id,
                 channel_type=channel_type,
                 receiver=receiver,
                 idle_minutes=(now - last_active) / 60 if last_active > 0 else 0.0,

--- a/agent/registry.py
+++ b/agent/registry.py
@@ -1,0 +1,238 @@
+"""Agent profile registry.
+
+The registry is deliberately small: an agent is identified by a stable ID and
+one complete CowAgent workspace. Runtime, routing, and persistence layers build
+on this module without changing the existing single-agent configuration path.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from common.utils import expand_path
+
+
+_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class AgentRegistryError(ValueError):
+    """Raised when agent configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    """Configuration for one complete CowAgent workspace."""
+
+    id: str
+    name: str
+    workspace: str
+    enabled: bool = True
+    model: Optional[str] = None
+    bot_type: Optional[str] = None
+
+    @property
+    def workspace_path(self) -> Path:
+        return Path(self.workspace)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "workspace": self.workspace,
+            "enabled": self.enabled,
+        }
+        if self.model:
+            data["model"] = self.model
+        if self.bot_type:
+            data["bot_type"] = self.bot_type
+        return data
+
+
+def _normalise_workspace(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AgentRegistryError("agent workspace must be a non-empty string")
+    return str(Path(expand_path(value.strip())).resolve(strict=False))
+
+
+def _profile_from_mapping(raw: Mapping[str, Any]) -> AgentProfile:
+    agent_id = raw.get("id")
+    if not isinstance(agent_id, str) or not _AGENT_ID_RE.fullmatch(agent_id):
+        raise AgentRegistryError(
+            "agent id must be 1-64 URL-safe characters: letters, numbers, _ or -"
+        )
+
+    name = raw.get("name", agent_id)
+    if not isinstance(name, str) or not name.strip():
+        raise AgentRegistryError(f"agent '{agent_id}' name must be a non-empty string")
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise AgentRegistryError(f"agent '{agent_id}' enabled must be a boolean")
+
+    model = raw.get("model")
+    bot_type = raw.get("bot_type")
+    for key, value in (("model", model), ("bot_type", bot_type)):
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise AgentRegistryError(
+                f"agent '{agent_id}' {key} must be a non-empty string when set"
+            )
+
+    return AgentProfile(
+        id=agent_id,
+        name=name.strip(),
+        workspace=_normalise_workspace(raw.get("workspace")),
+        enabled=enabled,
+        model=model.strip() if isinstance(model, str) else None,
+        bot_type=bot_type.strip() if isinstance(bot_type, str) else None,
+    )
+
+
+class AgentRegistry:
+    """Thread-safe registry of configured agent workspaces."""
+
+    def __init__(self, profiles: Iterable[AgentProfile], default_agent_id: str):
+        self._lock = threading.RLock()
+        self._profiles: Dict[str, AgentProfile] = {}
+        self._default_agent_id = default_agent_id
+
+        workspaces: Dict[str, str] = {}
+        for profile in profiles:
+            if profile.id in self._profiles:
+                raise AgentRegistryError(f"duplicate agent id: {profile.id}")
+            owner = workspaces.get(profile.workspace)
+            if owner is not None:
+                raise AgentRegistryError(
+                    f"agents '{owner}' and '{profile.id}' share workspace "
+                    f"'{profile.workspace}'"
+                )
+            self._profiles[profile.id] = profile
+            workspaces[profile.workspace] = profile.id
+
+        if not self._profiles:
+            raise AgentRegistryError("at least one agent profile is required")
+        self._validate_default(default_agent_id)
+
+    @classmethod
+    def from_config(cls, settings: Mapping[str, Any]) -> "AgentRegistry":
+        raw_agents = settings.get("agents")
+        if raw_agents is None or raw_agents == []:
+            workspace = settings.get("agent_workspace", "~/cow")
+            profile = AgentProfile(
+                id="default",
+                name="Default",
+                workspace=_normalise_workspace(workspace),
+            )
+            return cls([profile], "default")
+
+        if not isinstance(raw_agents, list):
+            raise AgentRegistryError("agents must be a list")
+        profiles: List[AgentProfile] = []
+        for index, raw in enumerate(raw_agents):
+            if not isinstance(raw, Mapping):
+                raise AgentRegistryError(f"agents[{index}] must be an object")
+            profiles.append(_profile_from_mapping(raw))
+
+        default_agent_id = settings.get("default_agent_id", "default")
+        if not isinstance(default_agent_id, str) or not default_agent_id:
+            raise AgentRegistryError("default_agent_id must be a non-empty string")
+        return cls(profiles, default_agent_id)
+
+    @property
+    def default_agent_id(self) -> str:
+        with self._lock:
+            return self._default_agent_id
+
+    def _validate_default(self, agent_id: str) -> None:
+        profile = self._profiles.get(agent_id)
+        if profile is None:
+            raise AgentRegistryError(f"default agent '{agent_id}' is not configured")
+        if not profile.enabled:
+            raise AgentRegistryError(f"default agent '{agent_id}' is disabled")
+
+    def get(self, agent_id: Optional[str] = None, require_enabled: bool = True) -> AgentProfile:
+        with self._lock:
+            resolved_id = agent_id or self._default_agent_id
+            profile = self._profiles.get(resolved_id)
+            if profile is None:
+                raise KeyError(resolved_id)
+            if require_enabled and not profile.enabled:
+                raise AgentRegistryError(f"agent '{resolved_id}' is disabled")
+            return profile
+
+    def get_or_default(self, agent_id: Optional[str]) -> AgentProfile:
+        with self._lock:
+            profile = self._profiles.get(agent_id) if agent_id else None
+            if profile is not None and profile.enabled:
+                return profile
+            return self._profiles[self._default_agent_id]
+
+    def list(self, include_disabled: bool = True) -> List[AgentProfile]:
+        with self._lock:
+            profiles = list(self._profiles.values())
+            if not include_disabled:
+                profiles = [profile for profile in profiles if profile.enabled]
+            return sorted(profiles, key=lambda profile: profile.id)
+
+    def upsert(self, profile: AgentProfile) -> None:
+        with self._lock:
+            for existing in self._profiles.values():
+                if existing.id != profile.id and existing.workspace == profile.workspace:
+                    raise AgentRegistryError(
+                        f"agents '{existing.id}' and '{profile.id}' share workspace "
+                        f"'{profile.workspace}'"
+                    )
+            self._profiles[profile.id] = profile
+            self._validate_default(self._default_agent_id)
+
+    def set_enabled(self, agent_id: str, enabled: bool) -> AgentProfile:
+        with self._lock:
+            current = self.get(agent_id, require_enabled=False)
+            if agent_id == self._default_agent_id and not enabled:
+                raise AgentRegistryError("the default agent cannot be disabled")
+            updated = replace(current, enabled=enabled)
+            self._profiles[agent_id] = updated
+            return updated
+
+    def set_default(self, agent_id: str) -> None:
+        with self._lock:
+            profile = self.get(agent_id, require_enabled=True)
+            self._default_agent_id = profile.id
+
+    def remove(self, agent_id: str) -> AgentProfile:
+        with self._lock:
+            if agent_id == self._default_agent_id:
+                raise AgentRegistryError("the default agent cannot be removed")
+            try:
+                return self._profiles.pop(agent_id)
+            except KeyError:
+                raise KeyError(agent_id) from None
+
+
+_registry_instance: Optional[AgentRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_agent_registry() -> AgentRegistry:
+    """Return the process-wide registry built from the current configuration."""
+
+    global _registry_instance
+    if _registry_instance is not None:
+        return _registry_instance
+    with _registry_lock:
+        if _registry_instance is None:
+            from config import conf
+
+            _registry_instance = AgentRegistry.from_config(conf())
+        return _registry_instance
+
+
+def set_agent_registry(registry: Optional[AgentRegistry]) -> None:
+    """Replace the process registry, primarily for config reloads and tests."""
+
+    global _registry_instance
+    with _registry_lock:
+        _registry_instance = registry

--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -3,7 +3,8 @@ Agent Bridge - Integrates Agent system with existing COW bridge
 """
 
 import os
-from typing import Optional, List
+import threading
+from typing import Dict, Iterator, Optional, List, Tuple
 
 from agent.protocol import Agent, LLMModel, LLMRequest, get_cancel_registry
 from bridge.agent_event_handler import AgentEventHandler
@@ -279,8 +280,18 @@ class AgentBridge:
     
     def __init__(self, bridge: Bridge):
         self.bridge = bridge
-        self.agents = {}  # session_id -> Agent instance mapping
-        self.default_agent = None  # For backward compatibility (no session_id)
+        from agent.registry import get_agent_registry
+
+        self.agent_registry = get_agent_registry()
+        # Canonical runtime map. A session identifier is only unique inside an
+        # agent workspace, so the agent id is part of every live key.
+        self._agent_instances: Dict[Tuple[str, str], Agent] = {}
+        self._default_agents: Dict[str, Agent] = {}
+        self._agents_lock = threading.RLock()
+        # Backward-compatible view for integrations that inspect sessions of
+        # the configured default agent directly.
+        self.agents: Dict[str, Agent] = {}
+        self.default_agent = None
         self.agent: Optional[Agent] = None
         self.scheduler_initialized = False
         
@@ -360,39 +371,77 @@ class AgentBridge:
 
         return agent
     
-    def get_agent(self, session_id: str = None) -> Optional[Agent]:
+    def _resolve_agent_id(self, agent_id: str = None) -> str:
+        return self.agent_registry.get(agent_id).id
+
+    @staticmethod
+    def _runtime_key(agent_id: str, session_id: str) -> Tuple[str, str]:
+        return agent_id, session_id
+
+    @staticmethod
+    def _cancel_key(agent_id: str, token: str, default_agent_id: str) -> str:
+        """Keep legacy token keys for the default agent, namespace the rest."""
+        return token if agent_id == default_agent_id else f"{agent_id}::{token}"
+
+    def get_agent(self, session_id: str = None, agent_id: str = None) -> Optional[Agent]:
         """
         Get agent instance for the given session
         
         Args:
-            session_id: Session identifier (e.g., user_id). If None, returns default agent.
+            session_id: Session identifier (e.g., user_id). If None, returns
+                the workspace's default runtime instance.
+            agent_id: Agent profile identifier. Omit for the configured default.
         
         Returns:
             Agent instance for this session
         """
-        # If no session_id, use default agent (backward compatibility)
-        if session_id is None:
-            if self.default_agent is None:
-                self._init_default_agent()
-            return self.default_agent
-        
-        # Check if agent exists for this session
-        if session_id not in self.agents:
-            self._init_agent_for_session(session_id)
-        
-        return self.agents[session_id]
-    
-    def _init_default_agent(self):
-        """Initialize default super agent"""
-        agent = self.initializer.initialize_agent(session_id=None)
-        self.default_agent = agent
-    
-    def _init_agent_for_session(self, session_id: str):
-        """Initialize agent for a specific session"""
-        agent = self.initializer.initialize_agent(session_id=session_id)
-        self.agents[session_id] = agent
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        with self._agents_lock:
+            if session_id is None:
+                agent = self._default_agents.get(resolved_agent_id)
+                if agent is None:
+                    agent = self.initializer.initialize_agent(
+                        session_id=None, agent_id=resolved_agent_id
+                    )
+                    self._default_agents[resolved_agent_id] = agent
+                if resolved_agent_id == self.agent_registry.default_agent_id:
+                    self.default_agent = agent
+                return agent
 
-    def sync_session_messages_from_store(self, session_id: str) -> int:
+            key = self._runtime_key(resolved_agent_id, session_id)
+            agent = self._agent_instances.get(key)
+            if agent is None:
+                agent = self.initializer.initialize_agent(
+                    session_id=session_id, agent_id=resolved_agent_id
+                )
+                self._agent_instances[key] = agent
+                if resolved_agent_id == self.agent_registry.default_agent_id:
+                    self.agents[session_id] = agent
+            return agent
+
+    def get_cached_agent(self, session_id: str, agent_id: str = None) -> Optional[Agent]:
+        """Return an existing session agent without creating one."""
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        with self._agents_lock:
+            return self._agent_instances.get(
+                self._runtime_key(resolved_agent_id, session_id)
+            )
+
+    def iter_agent_instances(
+        self, include_defaults: bool = True
+    ) -> Iterator[Tuple[str, Optional[str], Agent]]:
+        """Snapshot all live instances as ``(agent_id, session_id, agent)``."""
+        with self._agents_lock:
+            defaults = list(self._default_agents.items()) if include_defaults else []
+            sessions = list(self._agent_instances.items())
+        for agent_id, agent in defaults:
+            yield agent_id, None, agent
+        for (agent_id, session_id), agent in sessions:
+            yield agent_id, session_id, agent
+
+    def sync_session_messages_from_store(
+        self, session_id: str, agent_id: str = None
+    ) -> int:
         """Reload an agent's in-memory ``messages`` list from the persistent
         conversation store.
 
@@ -405,9 +454,11 @@ class AgentBridge:
             Number of messages now held in the agent's memory. Returns -1 if
             the agent does not exist or has no compatible ``messages`` attr.
         """
-        if not session_id or session_id not in self.agents:
+        if not session_id:
             return -1
-        agent = self.agents[session_id]
+        agent = self.get_cached_agent(session_id, agent_id=agent_id)
+        if agent is None:
+            return -1
         if not (hasattr(agent, "messages") and hasattr(agent, "messages_lock")):
             return -1
         try:
@@ -449,14 +500,19 @@ class AgentBridge:
             Reply object
         """
         session_id = None
+        agent_id = None
         agent = None
         request_id = None
         cancel_event = None
+        token_key = None
         try:
             # Extract session_id from context for user isolation
             if context:
                 session_id = context.kwargs.get("session_id") or context.get("session_id")
+                agent_id = context.kwargs.get("agent_id") or context.get("agent_id")
                 request_id = context.kwargs.get("request_id") or context.get("request_id")
+
+            resolved_agent_id = self._resolve_agent_id(agent_id)
 
             # Register a cancel token. Prefer per-turn request_id (web),
             # fall back to session_id (IM channels). The Event is polled by
@@ -464,10 +520,17 @@ class AgentBridge:
             registry = get_cancel_registry()
             token_key = request_id or session_id
             if token_key:
+                token_key = self._cancel_key(
+                    resolved_agent_id,
+                    token_key,
+                    self.agent_registry.default_agent_id,
+                )
                 cancel_event = registry.register(token_key, session_id=session_id)
 
             # Get agent for this session (will auto-initialize if needed)
-            agent = self.get_agent(session_id=session_id)
+            agent = self.get_agent(
+                session_id=session_id, agent_id=resolved_agent_id
+            )
             if not agent:
                 return Reply(ReplyType.ERROR, "Failed to initialize super agent")
             
@@ -499,9 +562,11 @@ class AgentBridge:
             if context and hasattr(agent, 'model'):
                 agent.model.channel_type = context.get("channel_type", "")
                 agent.model.session_id = session_id or ""
+                agent.model.agent_id = resolved_agent_id
 
             # Store session_id on agent so executor can clear DB on fatal errors
             agent._current_session_id = session_id
+            agent._current_agent_id = resolved_agent_id
 
             # Bound the in-memory context for scheduler sessions before each run.
             # Scheduler sessions are stable per-task and append every trigger,
@@ -638,9 +703,9 @@ class AgentBridge:
                 except Exception as db_err:
                     logger.warning(f"[AgentBridge] Failed to clear DB after error: {db_err}")
             # Release cancel token on error path too (idempotent).
-            if cancel_event is not None and (request_id or session_id):
+            if cancel_event is not None and token_key:
                 try:
-                    get_cancel_registry().unregister(request_id or session_id)
+                    get_cancel_registry().unregister(token_key)
                 except Exception:
                     pass
             return Reply(ReplyType.ERROR, f"Agent error: {str(e)}")
@@ -887,6 +952,7 @@ class AgentBridge:
         content: str,
         channel_type: str = "",
         task_description: str = "",
+        agent_id: str = None,
     ) -> None:
         """Add the visible output of a scheduled task to the receiver's session.
 
@@ -945,7 +1011,7 @@ class AgentBridge:
                 f"for session={session_id}: {e}"
             )
 
-        agent = self.agents.get(session_id)
+        agent = self.get_cached_agent(session_id, agent_id=agent_id)
         if agent:
             try:
                 with agent.messages_lock:
@@ -1091,22 +1157,49 @@ class AgentBridge:
                 cleaned.append(new_msg)
         return cleaned
 
-    def clear_session(self, session_id: str):
+    def clear_session(self, session_id: str, agent_id: str = None):
         """
         Clear a specific session's agent and conversation history
         
         Args:
             session_id: Session identifier to clear
         """
-        if session_id in self.agents:
-            logger.info(f"[AgentBridge] Clearing session: {session_id}")
-            del self.agents[session_id]
+        if not session_id:
+            return
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        key = self._runtime_key(resolved_agent_id, session_id)
+        with self._agents_lock:
+            removed = self._agent_instances.pop(key, None)
+            if resolved_agent_id == self.agent_registry.default_agent_id:
+                self.agents.pop(session_id, None)
+        if removed is not None:
+            logger.info(
+                f"[AgentBridge] Clearing session: agent={resolved_agent_id}, "
+                f"session={session_id}"
+            )
+
+    def clear_agent(self, agent_id: str) -> int:
+        """Evict every live runtime instance for one agent workspace."""
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        with self._agents_lock:
+            keys = [key for key in self._agent_instances if key[0] == resolved_agent_id]
+            for key in keys:
+                self._agent_instances.pop(key, None)
+            self._default_agents.pop(resolved_agent_id, None)
+            if resolved_agent_id == self.agent_registry.default_agent_id:
+                self.agents.clear()
+                self.default_agent = None
+        return len(keys)
     
     def clear_all_sessions(self):
         """Clear all agent sessions"""
-        logger.info(f"[AgentBridge] Clearing all sessions ({len(self.agents)} total)")
-        self.agents.clear()
-        self.default_agent = None
+        with self._agents_lock:
+            count = len(self._agent_instances)
+            logger.info(f"[AgentBridge] Clearing all sessions ({count} total)")
+            self._agent_instances.clear()
+            self._default_agents.clear()
+            self.agents.clear()
+            self.default_agent = None
     
     def refresh_all_skills(self) -> int:
         """
@@ -1120,24 +1213,18 @@ class AgentBridge:
         from dotenv import load_dotenv
         from config import conf
 
-        # Reload environment variables from .env file
-        workspace_root = expand_path(conf().get("agent_workspace", "~/cow"))
-        env_file = os.path.join(workspace_root, '.env')
-
-        if os.path.exists(env_file):
-            load_dotenv(env_file, override=True)
-            logger.info(f"[AgentBridge] Reloaded environment variables from {env_file}")
-
         refreshed_count = 0
+        loaded_env_files = set()
 
-        # Collect all agent instances to refresh
-        agents_to_refresh = []
-        if self.default_agent:
-            agents_to_refresh.append(("default", self.default_agent))
-        for session_id, agent in self.agents.items():
-            agents_to_refresh.append((session_id, agent))
-
-        for label, agent in agents_to_refresh:
+        for agent_id, session_id, agent in self.iter_agent_instances():
+            workspace_root = getattr(agent, "workspace_dir", None)
+            env_file = os.path.join(workspace_root, ".env") if workspace_root else None
+            if env_file and env_file not in loaded_env_files and os.path.exists(env_file):
+                load_dotenv(env_file, override=True)
+                loaded_env_files.add(env_file)
+                logger.info(
+                    f"[AgentBridge] Reloaded environment variables from {env_file}"
+                )
             # Refresh skills
             if hasattr(agent, 'skill_manager') and agent.skill_manager:
                 agent.skill_manager.refresh_skills()

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -38,20 +38,25 @@ class AgentInitializer:
         self.bridge = bridge
         self.agent_bridge = agent_bridge
     
-    def initialize_agent(self, session_id: Optional[str] = None) -> Agent:
+    def initialize_agent(
+        self,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Agent:
         """
         Initialize agent for a session
         
         Args:
             session_id: Session ID (None for default agent)
+            agent_id: Agent profile identifier. Omit for the configured default.
         
         Returns:
             Initialized agent instance
         """
         from config import conf
-        
-        # Get workspace from config
-        workspace_root = expand_path(conf().get("agent_workspace", "~/cow"))
+
+        profile = self.agent_bridge.agent_registry.get(agent_id)
+        workspace_root = profile.workspace
         
         # Migrate API keys
         self._migrate_config_to_env(workspace_root)
@@ -84,6 +89,8 @@ class AgentInitializer:
         # Build system prompt
         prompt_builder = PromptBuilder(workspace_dir=workspace_root, language="zh")
         runtime_info = self._get_runtime_info(workspace_root)
+        runtime_info["agent_id"] = profile.id
+        runtime_info["agent_name"] = profile.name
         
         system_prompt = prompt_builder.build(
             tools=tools,
@@ -116,6 +123,10 @@ class AgentInitializer:
             agent.memory_manager = memory_manager
             if hasattr(agent, 'model') and agent.model:
                 memory_manager.flush_manager.llm_model = agent.model
+
+        agent.agent_id = profile.id
+        agent.agent_profile = profile
+        agent.workspace_dir = workspace_root
 
         # Restore persisted conversation history for this session
         if session_id:
@@ -608,11 +619,10 @@ class AgentInitializer:
 
     def _flush_all_agents(self):
         """Flush memory for all active agent sessions, then run Deep Dream."""
-        agents = []
-        if self.agent_bridge.default_agent:
-            agents.append(("default", self.agent_bridge.default_agent))
-        for sid, agent in self.agent_bridge.agents.items():
-            agents.append((sid, agent))
+        agents = [
+            (f"{agent_id}:{session_id or 'default'}", agent)
+            for agent_id, session_id, agent in self.agent_bridge.iter_agent_instances()
+        ]
 
         if not agents:
             return

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -4759,9 +4759,7 @@ class SessionDetailHandler:
             try:
                 from bridge.bridge import Bridge
                 ab = Bridge().get_agent_bridge()
-                if session_id in ab.agents:
-                    del ab.agents[session_id]
-                    logger.info(f"[WebChannel] Removed agent instance for session {session_id}")
+                ab.clear_session(session_id)
             except Exception:
                 pass
 
@@ -4840,9 +4838,7 @@ class SessionClearContextHandler:
                 from bridge.bridge import Bridge
                 bridge = Bridge()
                 ab = bridge.get_agent_bridge()
-                if session_id in ab.agents:
-                    del ab.agents[session_id]
-                    logger.info(f"[WebChannel] Cleared agent instance for session {session_id}")
+                ab.clear_session(session_id)
             except Exception:
                 pass
 

--- a/config.py
+++ b/config.py
@@ -257,6 +257,12 @@ available_setting = {
     "mcp_oauth_redirect_base": "",  # Base URL for MCP OAuth callback (e.g. http://your-ip:9899); empty uses local web console
     "agent": True,  # whether to enable Agent mode
     "agent_workspace": "~/cow",  # agent workspace path, used to store skills, memory, etc.
+    # Optional native multi-agent registry. When empty or omitted, CowAgent
+    # synthesizes one "default" agent from agent_workspace and behaves exactly
+    # as before. Each configured workspace is a complete CowAgent workspace.
+    "agents": [],
+    "default_agent_id": "default",
+    "agent_bindings": [],
     "agent_max_context_tokens": 50000,  # max context tokens in Agent mode
     "agent_max_context_turns": 20,  # max context memory turns in Agent mode
     "agent_max_steps": 20,  # max decision steps per run in Agent mode

--- a/docs/superpowers/plans/2026-07-19-native-multi-agent-implementation.md
+++ b/docs/superpowers/plans/2026-07-19-native-multi-agent-implementation.md
@@ -1,0 +1,86 @@
+# Native Multi-Agent Implementation Plan
+
+## Change 1: Agent registry
+
+- Add immutable `AgentProfile` values and a thread-safe `AgentRegistry`.
+- Parse `agents`, `default_agent_id`, and `agent_bindings` from configuration.
+- Synthesize the default profile from `agent_workspace` when the new fields are
+  absent.
+- Validate IDs, duplicate workspaces, enabled defaults, and binding targets.
+- Add unit tests for compatibility and invalid configurations.
+
+Verification: registry tests, configuration tests, Python compilation.
+
+## Change 2: Runtime isolation
+
+- Thread `agent_id` through `AgentBridge`, `AgentInitializer`, and chat service.
+- Key live agent instances by `(agent_id, session_id)`.
+- Pass the resolved workspace explicitly to prompt, tools, skills, memory, and
+  runtime metadata.
+- Add eviction helpers for one agent and one agent session.
+- Test same-session isolation and legacy callers.
+
+Verification: bridge/initializer tests and existing agent tests.
+
+## Change 3: Workspace-scoped state
+
+- Replace memory and conversation process singletons with workspace registries.
+- Replace scheduler singleton access with workspace-scoped services and stores.
+- Scope flush, Deep Dream, evolution, session operations, and task execution to
+  the owning workspace.
+- Keep the existing database schema and file layout.
+- Test independent databases, tasks, timers, and cleanup.
+
+Verification: memory, conversation, scheduler, evolution, and regression tests.
+
+## Change 4: Routing
+
+- Add a binding resolver with exact, channel-default, and global-default
+  precedence.
+- Add `agent_id` to inbound contexts and preserve it through queues, replies,
+  persistence, and cancellation.
+- Add Web chat agent selection.
+- Test private chats, groups, missing targets, disabled targets, and unchanged
+  default routing.
+
+Verification: routing and representative channel tests.
+
+## Change 5: Web management
+
+- Add authenticated APIs for agent CRUD, bindings, and allowed core files.
+- Use atomic writes, path containment checks, and content revisions.
+- Add an Agents page and selectors in chat, sessions, tasks, memory, skills, and
+  knowledge views where relevant.
+- Evict only the affected agent after core-file changes.
+- Test API authorization, validation, traversal protection, conflicts, and UI
+  production build.
+
+Verification: API tests, TypeScript checks, and desktop production build.
+
+## Change 6: Delegation
+
+- Add a delegation service and `agent_delegate` tool.
+- Create stable target relay sessions without user-channel delivery.
+- Enforce target policy, timeout, cancellation, depth, cycle, size, and
+  concurrency limits.
+- Return structured provenance and errors.
+- Test success, unavailable targets, timeout, cancellation, and cycles.
+
+Verification: delegation tests and agent tool regressions.
+
+## Change 7: Backup and hardening
+
+- Extend the backup manifest with registry, bindings, and selected workspaces.
+- Preserve archive traversal, destination, and rollback protections.
+- Add single-agent and all-agent backup/restore tests.
+- Update English, Chinese, and Japanese documentation.
+- Run the complete Python suite and desktop build against the final stack.
+
+Verification: backup tests, full Python suite, desktop build, and diff checks.
+
+## Publication
+
+- Preserve one branch pointer after each ordered change.
+- Push all implementation branches only after the final stack passes.
+- Open reviewable pull requests with explicit dependency notes and validation.
+- Open one tracking issue describing the completed work and merge order.

--- a/docs/superpowers/specs/2026-07-19-native-multi-agent-design.md
+++ b/docs/superpowers/specs/2026-07-19-native-multi-agent-design.md
@@ -1,0 +1,155 @@
+# Native Multi-Agent Workspaces
+
+## Goal
+
+Allow one CowAgent process to host multiple agents without changing the
+behaviour of existing single-agent installations. Each agent is a complete
+CowAgent workspace, not a lightweight persona overlay.
+
+## Workspace model
+
+An agent profile identifies one workspace root. The existing workspace layout
+is reused unchanged:
+
+```text
+<workspace>/
+├── AGENT.md
+├── USER.md
+├── RULE.md
+├── MEMORY.md
+├── memory/
+├── skills/
+├── knowledge/
+├── output/
+└── scheduler/
+```
+
+The workspace owns the agent's persona, user profile, rules, long-term memory,
+daily memory, search index, conversation history, skills, knowledge, scheduler
+tasks, evolution data, and generated output.
+
+There is no second home directory abstraction. There is also no shared memory
+database with an `agent_id` column. Each workspace keeps using its own
+`memory/long-term/index.db`, matching the current single-agent layout.
+
+## Configuration
+
+The optional configuration is:
+
+```json
+{
+  "default_agent_id": "default",
+  "agents": [
+    {
+      "id": "default",
+      "name": "Default",
+      "workspace": "~/cow",
+      "enabled": true
+    }
+  ],
+  "agent_bindings": []
+}
+```
+
+When `agents` is absent, CowAgent synthesizes one `default` profile from the
+existing `agent_workspace` value. Existing configuration and data therefore
+continue to work without a migration.
+
+Agent IDs are stable, URL-safe identifiers. Workspace paths must be unique.
+Agent deletion is represented as disabling or archiving the profile; workspace
+data is never deleted implicitly.
+
+## Runtime isolation
+
+The runtime key becomes `(agent_id, session_id)`. Initializing an agent resolves
+the profile first, then passes its workspace explicitly through prompt loading,
+memory, tools, skills, scheduler, and persistence.
+
+Process-wide state that currently binds to the first workspace is replaced by
+workspace-keyed registries:
+
+```text
+workspace → MemoryManager
+workspace → ConversationStore
+workspace → SchedulerService / TaskStore
+workspace → memory flush, Deep Dream, and evolution runtime
+```
+
+No agent may obtain a manager, store, or scheduler belonging to another
+workspace, even when both sessions use the same external session identifier.
+
+## Routing
+
+Inbound contexts carry `agent_id`. Resolution follows a deterministic order:
+
+1. exact channel and conversation binding;
+2. channel-level default binding;
+3. configured `default_agent_id`.
+
+Bindings that reference a missing or disabled agent fall back to the default
+agent and emit a warning. Existing channels require no binding and continue to
+use the default agent.
+
+## Web console
+
+The console can list, create, clone, enable, disable, and select agents. It can
+edit the four core files `AGENT.md`, `USER.md`, `RULE.md`, and `MEMORY.md`.
+
+The editor is intentionally not a general filesystem browser. The backend uses
+an allowlist, resolves paths beneath the selected workspace, writes atomically,
+and rejects stale writes using a content revision. Updating a core file evicts
+only that agent's live sessions so its next turn rebuilds the prompt.
+
+New profiles use the existing workspace bootstrap and templates. A new agent
+therefore has the same onboarding and capabilities as the original single
+agent.
+
+## Inter-agent delegation
+
+Agents communicate through a guarded request-response tool:
+
+```text
+agent_delegate(target_agent, message, timeout_seconds)
+```
+
+The target runs in its own workspace and a dedicated relay session. Results
+include source attribution and structured errors. The runtime enforces target
+allowlists, timeouts, cancellation, message limits, maximum delegation depth,
+and cycle detection. Delegated output is returned to the caller and is not sent
+to a user channel automatically.
+
+## Backup and restore
+
+Backups include the registry, bindings, and selected agent workspaces. Restore
+validates manifest versions, profile IDs, workspace destinations, and archive
+paths before writing. Restores remain transactional and preserve the existing
+rollback behaviour.
+
+No import tooling is part of this design.
+
+## Delivery
+
+The work is split into seven ordered changes:
+
+1. agent registry and compatibility configuration;
+2. agent-aware runtime initialization;
+3. workspace-scoped memory, sessions, and scheduler;
+4. channel bindings and routing;
+5. Web console management and core-file editor;
+6. guarded inter-agent delegation;
+7. multi-agent backup, documentation, and final hardening.
+
+Later changes depend on earlier ones. Each change must include its own tests and
+preserve the zero-configuration single-agent path.
+
+## Acceptance criteria
+
+- Existing configurations still use `~/cow` exactly as before.
+- Two agents with the same session ID cannot share runtime state or data.
+- Memory, conversation history, scheduled tasks, skills, and knowledge remain
+  inside the selected workspace.
+- Channel bindings resolve deterministically and fail safely.
+- The console can create an agent and safely edit its four core Markdown files.
+- Delegation cannot recurse forever or bypass disabled-target checks.
+- Backup and restore preserve all configured agents without writing outside
+  approved workspace paths.

--- a/plugins/cow_cli/cow_cli.py
+++ b/plugins/cow_cli/cow_cli.py
@@ -949,7 +949,7 @@ class CowCliPlugin(Plugin):
             from bridge.bridge import Bridge
             bridge = Bridge()
             agent_bridge = bridge.get_agent_bridge()
-            for agent in [agent_bridge.default_agent] + list(agent_bridge.agents.values()):
+            for _agent_id, _session_id, agent in agent_bridge.iter_agent_instances():
                 if agent and hasattr(agent, 'skill_manager') and agent.skill_manager:
                     agent.skill_manager.refresh_skills()
                     break

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+import pytest
+
+from agent.registry import AgentProfile, AgentRegistry, AgentRegistryError
+
+
+def test_legacy_config_synthesizes_default_agent(tmp_path):
+    workspace = tmp_path / "cow"
+    registry = AgentRegistry.from_config({"agent_workspace": str(workspace)})
+
+    profile = registry.get()
+    assert profile.id == "default"
+    assert profile.name == "Default"
+    assert profile.workspace_path == workspace.resolve()
+    assert registry.default_agent_id == "default"
+
+
+def test_configured_agents_keep_separate_workspaces(tmp_path):
+    registry = AgentRegistry.from_config(
+        {
+            "default_agent_id": "writer",
+            "agents": [
+                {"id": "writer", "name": "Writer", "workspace": str(tmp_path / "writer")},
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "workspace": str(tmp_path / "research"),
+                    "model": "gpt-5",
+                    "bot_type": "openai",
+                },
+            ],
+        }
+    )
+
+    assert registry.get().id == "writer"
+    assert registry.get("research").model == "gpt-5"
+    assert registry.get("research").bot_type == "openai"
+    assert [profile.id for profile in registry.list()] == ["research", "writer"]
+
+
+@pytest.mark.parametrize("agent_id", ["", "has space", "/root", "x" * 65])
+def test_invalid_agent_ids_are_rejected(tmp_path, agent_id):
+    with pytest.raises(AgentRegistryError, match="agent id"):
+        AgentRegistry.from_config(
+            {"agents": [{"id": agent_id, "workspace": str(tmp_path / "one")}]}
+        )
+
+
+def test_duplicate_ids_and_workspaces_are_rejected(tmp_path):
+    with pytest.raises(AgentRegistryError, match="duplicate agent id"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "one")},
+                    {"id": "one", "workspace": str(tmp_path / "two")},
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+    with pytest.raises(AgentRegistryError, match="share workspace"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "shared")},
+                    {"id": "two", "workspace": str(tmp_path / "shared")},
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+
+def test_default_agent_must_exist_and_be_enabled(tmp_path):
+    with pytest.raises(AgentRegistryError, match="not configured"):
+        AgentRegistry.from_config(
+            {
+                "agents": [{"id": "one", "workspace": str(tmp_path / "one")}],
+                "default_agent_id": "missing",
+            }
+        )
+
+    with pytest.raises(AgentRegistryError, match="disabled"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "one"), "enabled": False}
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+
+def test_registry_mutations_preserve_default_invariants(tmp_path):
+    registry = AgentRegistry.from_config({"agent_workspace": str(tmp_path / "default")})
+    second = AgentProfile(
+        id="second",
+        name="Second",
+        workspace=str((tmp_path / "second").resolve()),
+    )
+    registry.upsert(second)
+
+    registry.set_default("second")
+    registry.set_enabled("default", False)
+    assert registry.get().id == "second"
+    assert registry.get_or_default("default").id == "second"
+
+    with pytest.raises(AgentRegistryError, match="default agent cannot be disabled"):
+        registry.set_enabled("second", False)
+    with pytest.raises(AgentRegistryError, match="default agent cannot be removed"):
+        registry.remove("second")
+
+    removed = registry.remove("default")
+    assert removed.id == "default"
+    assert [profile.id for profile in registry.list()] == ["second"]
+
+
+def test_profile_to_dict_omits_empty_overrides(tmp_path):
+    profile = AgentProfile(
+        id="default",
+        name="Default",
+        workspace=str(Path(tmp_path).resolve()),
+    )
+    assert profile.to_dict() == {
+        "id": "default",
+        "name": "Default",
+        "workspace": str(Path(tmp_path).resolve()),
+        "enabled": True,
+    }

--- a/tests/test_multi_agent_runtime.py
+++ b/tests/test_multi_agent_runtime.py
@@ -1,0 +1,132 @@
+import threading
+from types import SimpleNamespace
+
+from agent.registry import AgentRegistry
+from bridge.agent_bridge import AgentBridge
+
+
+class _FakeInitializer:
+    def __init__(self, registry):
+        self.registry = registry
+        self.calls = []
+
+    def initialize_agent(self, session_id=None, agent_id=None):
+        profile = self.registry.get(agent_id)
+        self.calls.append((profile.id, session_id))
+        return SimpleNamespace(
+            agent_id=profile.id,
+            workspace_dir=profile.workspace,
+            messages=[],
+            messages_lock=threading.RLock(),
+        )
+
+
+def _bridge(tmp_path):
+    registry = AgentRegistry.from_config(
+        {
+            "default_agent_id": "primary",
+            "agents": [
+                {
+                    "id": "primary",
+                    "name": "Primary",
+                    "workspace": str(tmp_path / "primary"),
+                },
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "workspace": str(tmp_path / "research"),
+                },
+            ],
+        }
+    )
+    bridge = object.__new__(AgentBridge)
+    bridge.agent_registry = registry
+    bridge._agent_instances = {}
+    bridge._default_agents = {}
+    bridge._agents_lock = threading.RLock()
+    bridge.agents = {}
+    bridge.default_agent = None
+    bridge.initializer = _FakeInitializer(registry)
+    return bridge
+
+
+def test_same_session_id_isolated_by_agent(tmp_path):
+    bridge = _bridge(tmp_path)
+
+    primary = bridge.get_agent(session_id="shared")
+    research = bridge.get_agent(session_id="shared", agent_id="research")
+
+    assert primary is not research
+    assert primary.workspace_dir != research.workspace_dir
+    assert bridge.get_agent(session_id="shared") is primary
+    assert bridge.get_agent(session_id="shared", agent_id="research") is research
+    assert bridge.initializer.calls == [
+        ("primary", "shared"),
+        ("research", "shared"),
+    ]
+
+
+def test_legacy_agents_view_contains_only_default_profile(tmp_path):
+    bridge = _bridge(tmp_path)
+
+    primary = bridge.get_agent(session_id="one")
+    bridge.get_agent(session_id="two", agent_id="research")
+
+    assert bridge.agents == {"one": primary}
+    assert set(bridge._agent_instances) == {
+        ("primary", "one"),
+        ("research", "two"),
+    }
+
+
+def test_default_runtime_is_per_agent_workspace(tmp_path):
+    bridge = _bridge(tmp_path)
+
+    primary = bridge.get_agent()
+    research = bridge.get_agent(agent_id="research")
+
+    assert primary is bridge.default_agent
+    assert primary is not research
+    assert bridge.get_agent() is primary
+    assert bridge.get_agent(agent_id="research") is research
+
+
+def test_clear_session_and_agent_do_not_evict_other_agents(tmp_path):
+    bridge = _bridge(tmp_path)
+    primary = bridge.get_agent(session_id="shared")
+    research = bridge.get_agent(session_id="shared", agent_id="research")
+    bridge.get_agent(session_id="other", agent_id="research")
+
+    bridge.clear_session("shared", agent_id="research")
+    assert bridge.get_cached_agent("shared", agent_id="research") is None
+    assert bridge.get_cached_agent("shared") is primary
+
+    assert bridge.clear_agent("research") == 1
+    assert bridge.get_cached_agent("shared") is primary
+    assert bridge.get_cached_agent("other", agent_id="research") is None
+    assert research not in [item[2] for item in bridge.iter_agent_instances()]
+
+
+def test_iter_agent_instances_reports_agent_and_session(tmp_path):
+    bridge = _bridge(tmp_path)
+    bridge.get_agent()
+    bridge.get_agent(agent_id="research")
+    bridge.get_agent(session_id="chat")
+    bridge.get_agent(session_id="chat", agent_id="research")
+
+    keys = {
+        (agent_id, session_id)
+        for agent_id, session_id, _agent in bridge.iter_agent_instances()
+    }
+    assert keys == {
+        ("primary", None),
+        ("research", None),
+        ("primary", "chat"),
+        ("research", "chat"),
+    }
+
+
+def test_non_default_cancel_keys_are_namespaced(tmp_path):
+    bridge = _bridge(tmp_path)
+    assert bridge._cancel_key("primary", "session", "primary") == "session"
+    assert bridge._cancel_key("research", "session", "primary") == "research::session"


### PR DESCRIPTION
## Summary

- key live Agent instances by both Agent ID and session ID
- initialize prompts, skills, tools, and working directories from the selected Agent workspace
- keep the legacy default-Agent cache view for existing integrations
- scope clear, cancel, and runtime iteration operations so one Agent cannot evict another

## Stack

Depends on #2969. Please merge the series in order; after #2969 lands, the earlier registry diff will disappear from this PR.

## Test

```bash
python -m pytest -q tests/test_multi_agent_runtime.py
```
