### PR TITLE
feat(agent): isolate multi-agent state stores

### DIFF
--- a/agent/chat/service.py
+++ b/agent/chat/service.py
@@ -297,7 +297,12 @@ class ChatService:
         # Persist new messages to SQLite so they survive restarts and
         # can be queried via the HISTORY interface.
         if new_messages:
-            self._persist_messages(session_id, list(new_messages), channel_type)
+            self._persist_messages(
+                session_id,
+                list(new_messages),
+                channel_type,
+                workspace_root=agent.workspace_dir,
+            )
 
         # Store executor reference for files_to_send access
         agent.stream_executor = executor
@@ -374,7 +379,12 @@ class ChatService:
             pass
 
     @staticmethod
-    def _persist_messages(session_id: str, new_messages: list, channel_type: str = ""):
+    def _persist_messages(
+        session_id: str,
+        new_messages: list,
+        channel_type: str = "",
+        workspace_root: str = None,
+    ):
         try:
             from config import conf
             if not conf().get("conversation_persistence", True):
@@ -383,7 +393,7 @@ class ChatService:
             pass
         try:
             from agent.memory import get_conversation_store
-            get_conversation_store().append_messages(
+            get_conversation_store(workspace_root).append_messages(
                 session_id, new_messages, channel_type=channel_type
             )
         except Exception as e:

--- a/agent/chat/service.py
+++ b/agent/chat/service.py
@@ -27,8 +27,14 @@ class ChatService:
         """
         self.agent_bridge = agent_bridge
 
-    def run(self, query: str, session_id: str, send_chunk_fn: Callable[[dict], None],
-            channel_type: str = ""):
+    def run(
+        self,
+        query: str,
+        session_id: str,
+        send_chunk_fn: Callable[[dict], None],
+        channel_type: str = "",
+        agent_id: str = None,
+    ):
         """
         Run the agent for *query* and stream results back via *send_chunk_fn*.
 
@@ -39,8 +45,12 @@ class ChatService:
         :param session_id: session identifier for agent isolation
         :param send_chunk_fn: callable(chunk_data: dict) to send a streaming chunk
         :param channel_type: source channel (e.g. "web", "feishu") for persistence
+        :param agent_id: selected agent profile; defaults to the configured default
         """
-        agent = self.agent_bridge.get_agent(session_id=session_id)
+        resolved_agent_id = self.agent_bridge._resolve_agent_id(agent_id)
+        agent = self.agent_bridge.get_agent(
+            session_id=session_id, agent_id=resolved_agent_id
+        )
         if agent is None:
             raise RuntimeError("Failed to initialise agent for the session")
 
@@ -48,11 +58,14 @@ class ChatService:
         if hasattr(agent, 'model'):
             agent.model.channel_type = channel_type or ""
             agent.model.session_id = session_id or ""
+            agent.model.agent_id = resolved_agent_id
 
         # Build a context so context-aware tools (e.g. scheduler) can resolve the
         # receiver/session. This streaming path bypasses agent_bridge.agent_reply,
         # so the attach step that normally happens there must be done here too.
-        context = self._build_context(query, session_id, channel_type)
+        context = self._build_context(
+            query, session_id, channel_type, resolved_agent_id
+        )
         self._attach_context_aware_tools(agent, context)
 
         # Mark this session as mid-run so the self-evolution idle scan does not
@@ -166,7 +179,10 @@ class ChatService:
                     state.segment_id += 1
 
         # Run the agent with our event callback ---------------------------
-        logger.info(f"[ChatService] Starting agent run: session={session_id}, query={query[:80]}")
+        logger.info(
+            f"[ChatService] Starting agent run: agent={resolved_agent_id}, "
+            f"session={session_id}, query={query[:80]}"
+        )
 
         from config import conf
         max_context_turns = conf().get("agent_max_context_turns", 20)
@@ -185,7 +201,16 @@ class ChatService:
         # IM channels key on session_id (no per-turn request_id here).
         from agent.protocol import get_cancel_registry
         registry = get_cancel_registry()
-        cancel_event = registry.register(session_id, session_id=session_id) if session_id else None
+        cancel_key = (
+            self.agent_bridge._cancel_key(
+                resolved_agent_id,
+                session_id,
+                self.agent_bridge.agent_registry.default_agent_id,
+            )
+            if session_id
+            else None
+        )
+        cancel_event = registry.register(cancel_key, session_id=session_id) if cancel_key else None
 
         executor = AgentStreamExecutor(
             agent=agent,
@@ -214,7 +239,7 @@ class ChatService:
             # Release cancel token to keep the registry bounded.
             if session_id:
                 try:
-                    registry.unregister(session_id)
+                    registry.unregister(cancel_key)
                 except Exception:
                     pass
 
@@ -285,12 +310,17 @@ class ChatService:
         # be noted here, otherwise idle scans never see any signal to evolve.
         self._note_evolution_turn(agent, context)
 
-        logger.info(f"[ChatService] Agent run completed: session={session_id}")
+        logger.info(
+            f"[ChatService] Agent run completed: agent={resolved_agent_id}, "
+            f"session={session_id}"
+        )
 
 
 
     @staticmethod
-    def _build_context(query: str, session_id: str, channel_type: str):
+    def _build_context(
+        query: str, session_id: str, channel_type: str, agent_id: str = "default"
+    ):
         """Build a Context for tool resolution on the streaming chat path.
 
         receiver falls back to session_id; the scheduler's delivery keys on
@@ -304,6 +334,7 @@ class ChatService:
         ctx["receiver"] = session_id
         ctx["isgroup"] = False
         ctx["channel_type"] = channel_type or ""
+        ctx["agent_id"] = agent_id
         return ctx
 
     @staticmethod

--- a/agent/chat/session_service.py
+++ b/agent/chat/session_service.py
@@ -85,16 +85,25 @@ class SessionService:
         result = svc.dispatch("list", {"channel_type": "web", "page": 1})
     """
 
-    def _get_store(self):
-        from agent.memory import get_conversation_store
-        return get_conversation_store()
+    def __init__(self, agent_id: str = None):
+        self.agent_id = agent_id
 
-    def _remove_agent(self, session_id: str):
+    def _resolve_agent_id(self, agent_id: str = None) -> str:
+        from agent.registry import get_agent_registry
+        return get_agent_registry().get(agent_id or self.agent_id).id
+
+    def _get_store(self, agent_id: str = None):
+        from agent.registry import get_agent_registry
+        from agent.memory import get_conversation_store
+        profile = get_agent_registry().get(agent_id or self.agent_id)
+        return get_conversation_store(profile.workspace)
+
+    def _remove_agent(self, session_id: str, agent_id: str = None):
         """Remove the in-memory Agent instance for a session if it exists."""
         try:
             from bridge.bridge import Bridge
             ab = Bridge().get_agent_bridge()
-            ab.clear_session(session_id)
+            ab.clear_session(session_id, agent_id=self._resolve_agent_id(agent_id))
         except Exception:
             pass
 
@@ -108,37 +117,40 @@ class SessionService:
     # actions
     # ------------------------------------------------------------------
     def list_sessions(self, channel_type: Optional[str] = None,
-                      page: int = 1, page_size: int = 50) -> dict:
-        store = self._get_store()
+                      page: int = 1, page_size: int = 50,
+                      agent_id: str = None) -> dict:
+        store = self._get_store(agent_id)
         return store.list_sessions(
             channel_type=channel_type,
             page=page,
             page_size=page_size,
         )
 
-    def delete_session(self, session_id: str) -> None:
+    def delete_session(self, session_id: str, agent_id: str = None) -> None:
         if not session_id:
             raise ValueError("session_id required")
         session_id = self._normalize_sid(session_id)
 
-        store = self._get_store()
+        store = self._get_store(agent_id)
         store.clear_session(session_id)
-        self._remove_agent(session_id)
+        self._remove_agent(session_id, agent_id)
         logger.info(f"[SessionService] Session deleted: {session_id}")
 
-    def rename_session(self, session_id: str, title: str) -> None:
+    def rename_session(
+        self, session_id: str, title: str, agent_id: str = None
+    ) -> None:
         if not session_id:
             raise ValueError("session_id required")
         if not title:
             raise ValueError("title required")
         session_id = self._normalize_sid(session_id)
 
-        store = self._get_store()
+        store = self._get_store(agent_id)
         found = store.rename_session(session_id, title)
         if not found:
             raise ValueError("session not found")
 
-    def clear_context(self, session_id: str) -> int:
+    def clear_context(self, session_id: str, agent_id: str = None) -> int:
         """
         Set context boundary. Returns the new context_start_seq value.
         """
@@ -146,13 +158,13 @@ class SessionService:
             raise ValueError("session_id required")
         session_id = self._normalize_sid(session_id)
 
-        store = self._get_store()
+        store = self._get_store(agent_id)
         new_seq = store.clear_context(session_id)
-        self._remove_agent(session_id)
+        self._remove_agent(session_id, agent_id)
         return new_seq
 
     def gen_title(self, session_id: str, user_message: str,
-                  assistant_reply: str = "") -> str:
+                  assistant_reply: str = "", agent_id: str = None) -> str:
         """
         Generate an AI title and persist it. Returns the generated title.
         """
@@ -164,7 +176,7 @@ class SessionService:
 
         title = generate_session_title(user_message, assistant_reply)
 
-        store = self._get_store()
+        store = self._get_store(agent_id)
         updated = store.rename_session(session_id, title)
         logger.info(f"[SessionService] Title set: sid={session_id}, "
                      f"title='{title}', db_updated={updated}")
@@ -194,28 +206,33 @@ class SessionService:
         :return: dict with action, code, message, payload
         """
         payload = payload or {}
+        agent_id = payload.get("agent_id") or self.agent_id
         try:
             if action == "list_sessions":
                 result = self.list_sessions(
                     channel_type=payload.get("channel_type"),
                     page=int(payload.get("page", 1)),
                     page_size=int(payload.get("page_size", 50)),
+                    agent_id=agent_id,
                 )
                 return {"action": action, "code": 200, "message": "success", "payload": result}
 
             elif action == "delete_session":
-                self.delete_session(payload.get("session_id", ""))
+                self.delete_session(payload.get("session_id", ""), agent_id=agent_id)
                 return {"action": action, "code": 200, "message": "success", "payload": None}
 
             elif action == "rename_session":
                 self.rename_session(
                     payload.get("session_id", ""),
                     payload.get("title", "").strip(),
+                    agent_id=agent_id,
                 )
                 return {"action": action, "code": 200, "message": "success", "payload": None}
 
             elif action == "clear_context":
-                new_seq = self.clear_context(payload.get("session_id", ""))
+                new_seq = self.clear_context(
+                    payload.get("session_id", ""), agent_id=agent_id
+                )
                 return {"action": action, "code": 200, "message": "success",
                         "payload": {"context_start_seq": new_seq}}
 
@@ -224,6 +241,7 @@ class SessionService:
                     payload.get("session_id", ""),
                     payload.get("user_message", ""),
                     payload.get("assistant_reply", ""),
+                    agent_id=agent_id,
                 )
                 return {"action": action, "code": 200, "message": "success",
                         "payload": {"title": title}}

--- a/agent/chat/session_service.py
+++ b/agent/chat/session_service.py
@@ -94,9 +94,7 @@ class SessionService:
         try:
             from bridge.bridge import Bridge
             ab = Bridge().get_agent_bridge()
-            if session_id in ab.agents:
-                del ab.agents[session_id]
-                logger.info(f"[SessionService] Removed agent instance: {session_id}")
+            ab.clear_session(session_id)
         except Exception:
             pass
 

--- a/agent/evolution/executor.py
+++ b/agent/evolution/executor.py
@@ -303,6 +303,7 @@ def _workspace_changed(workspace_dir, pre: dict) -> bool:
 def run_evolution_for_session(
     agent_bridge,
     session_id: str,
+    agent_id: str = "default",
     channel_type: str = "",
     receiver: str = "",
     user_id: Optional[str] = None,
@@ -329,7 +330,10 @@ def run_evolution_for_session(
         _running_count += 1
 
     try:
-        agent = agent_bridge.agents.get(session_id) or agent_bridge.default_agent
+        if hasattr(agent_bridge, "get_cached_agent"):
+            agent = agent_bridge.get_cached_agent(session_id, agent_id=agent_id)
+        else:
+            agent = agent_bridge.agents.get(session_id) or agent_bridge.default_agent
         if not agent:
             return False
 
@@ -359,8 +363,10 @@ def run_evolution_for_session(
         )
 
         # Resolve workspace + files to snapshot for undo.
-        from agent.memory.config import get_default_memory_config
-        mem_cfg = get_default_memory_config()
+        mem_cfg = getattr(getattr(agent, "memory_manager", None), "config", None)
+        if mem_cfg is None:
+            from agent.memory.config import get_default_memory_config
+            mem_cfg = get_default_memory_config()
         workspace_dir = mem_cfg.get_workspace()
         if user_id:
             memory_file = Path(workspace_dir) / "memory" / "users" / user_id / "MEMORY.md"
@@ -509,12 +515,15 @@ def _inject_evolution_record(
             note += f"\n(backup_id: {backup_id}; to undo, restore this backup)"
         # Reuse the scheduler-output injection path: isolated execution, only a
         # compact record lands in the user session.
-        agent_bridge.remember_scheduled_output(
-            session_id=session_id,
-            content=note,
-            channel_type=channel_type,
-            task_description="self-evolution",
-        )
+        remember_kwargs = {
+            "session_id": session_id,
+            "content": note,
+            "channel_type": channel_type,
+            "task_description": "self-evolution",
+        }
+        if hasattr(agent_bridge, "agent_registry"):
+            remember_kwargs["agent_id"] = agent_id
+        agent_bridge.remember_scheduled_output(**remember_kwargs)
     except Exception as e:
         logger.debug(f"[Evolution] Failed to inject evolution record: {e}")
 

--- a/agent/evolution/trigger.py
+++ b/agent/evolution/trigger.py
@@ -116,8 +116,14 @@ def _scan_loop(agent_bridge) -> None:
 def _scan_once(agent_bridge, cfg) -> None:
     now = time.time()
     # Snapshot to avoid holding the dict while running long evolutions.
-    sessions = list(getattr(agent_bridge, "agents", {}).items())
-    for session_id, agent in sessions:
+    if hasattr(agent_bridge, "iter_agent_instances"):
+        sessions = list(agent_bridge.iter_agent_instances(include_defaults=False))
+    else:
+        sessions = [
+            ("default", session_id, agent)
+            for session_id, agent in getattr(agent_bridge, "agents", {}).items()
+        ]
+    for agent_id, session_id, agent in sessions:
         try:
             # Skip sessions whose agent is mid-run: a long turn must not be
             # reviewed while it is still producing the answer.
@@ -143,6 +149,7 @@ def _scan_once(agent_bridge, cfg) -> None:
             run_evolution_for_session(
                 agent_bridge,
                 session_id=session_id,
+                agent_id=agent_id,
                 channel_type=channel_type,
                 receiver=receiver,
                 idle_minutes=(now - last_active) / 60 if last_active > 0 else 0.0,

--- a/agent/memory/__init__.py
+++ b/agent/memory/__init__.py
@@ -8,7 +8,11 @@ conversation history persistence (SQLite).
 from agent.memory.manager import MemoryManager
 from agent.memory.config import MemoryConfig, get_default_memory_config, set_global_memory_config
 from agent.memory.embedding import create_embedding_provider, create_default_embedding_provider
-from agent.memory.conversation_store import ConversationStore, get_conversation_store
+from agent.memory.conversation_store import (
+    ConversationStore,
+    clear_conversation_store_cache,
+    get_conversation_store,
+)
 from agent.memory.summarizer import ensure_daily_memory_file
 
 __all__ = [
@@ -19,6 +23,7 @@ __all__ = [
     'create_embedding_provider',
     'create_default_embedding_provider',
     'ConversationStore',
+    'clear_conversation_store_cache',
     'get_conversation_store',
     'ensure_daily_memory_file',
 ]

--- a/agent/memory/conversation_store.py
+++ b/agent/memory/conversation_store.py
@@ -7,7 +7,7 @@ Design:
 - Pruning: age-based only (sessions not updated within N days are deleted)
 - Thread-safe via a single in-process lock
 
-Storage path: ~/cow/sessions/conversations.db
+Storage path: <agent workspace>/memory/long-term/index.db
 """
 
 from __future__ import annotations
@@ -1245,34 +1245,59 @@ class ConversationStore:
 # ---------------------------------------------------------------------------
 
 _store_instance: Optional[ConversationStore] = None
-_store_lock = threading.Lock()
+_store_instances: Dict[str, ConversationStore] = {}
+_store_lock = threading.RLock()
 
 
-def get_conversation_store() -> ConversationStore:
-    """
-    Return the process-wide ConversationStore singleton.
-
-    Reuses the long-term memory database so the project stays with a single
-    SQLite file: ~/cow/memory/long-term/index.db
-    The conversation tables (sessions / messages) are separate from the
-    memory tables (memory_chunks / file_metadata) — no conflicts.
-    """
-    global _store_instance
-    if _store_instance is not None:
-        return _store_instance
-
-    with _store_lock:
-        if _store_instance is not None:
-            return _store_instance
-
+def _resolve_store_path(workspace_root=None) -> Path:
+    if workspace_root is None:
         try:
             from agent.memory.config import get_default_memory_config
-            db_path = get_default_memory_config().get_db_path()
+            return get_default_memory_config().get_db_path().resolve()
         except Exception:
             from common.utils import expand_path
-            db_path = Path(expand_path("~/cow")) / "memory" / "long-term" / "index.db"
+            return (
+                Path(expand_path("~/cow")) / "memory" / "long-term" / "index.db"
+            ).resolve()
+    from agent.memory.config import MemoryConfig
+    from common.utils import expand_path
+    workspace = Path(expand_path(str(workspace_root))).resolve()
+    return MemoryConfig(workspace_root=str(workspace)).get_db_path().resolve()
 
-        _store_instance = ConversationStore(db_path)
-        logger.debug(f"[ConversationStore] Using shared DB at: {db_path}")
-        return _store_instance
 
+def get_conversation_store(workspace_root=None) -> ConversationStore:
+    """
+    Return the ConversationStore for one complete agent workspace.
+
+    Reuses that workspace's long-term memory database, keeping one SQLite file
+    per agent at ``<workspace>/memory/long-term/index.db``.
+    The conversation tables (sessions / messages) are separate from the
+    memory tables (memory_chunks / file_metadata). Omitting ``workspace_root``
+    preserves the original single-agent behaviour.
+    """
+    global _store_instance
+    db_path = _resolve_store_path(workspace_root)
+    key = str(db_path)
+    store = _store_instances.get(key)
+    if store is not None:
+        if workspace_root is None:
+            _store_instance = store
+        return store
+
+    with _store_lock:
+        store = _store_instances.get(key)
+        if store is None:
+            store = ConversationStore(db_path)
+            _store_instances[key] = store
+            logger.debug(f"[ConversationStore] Using workspace DB at: {db_path}")
+        if workspace_root is None:
+            _store_instance = store
+        return store
+
+
+def clear_conversation_store_cache() -> None:
+    """Forget cached store objects. Intended for config reloads and tests."""
+    global _store_instance
+    with _store_lock:
+        _store_instances.clear()
+        _store_instance = None

--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -1786,7 +1786,8 @@ class AgentStreamExecutor:
             if not session_id:
                 return
             from agent.memory import get_conversation_store
-            store = get_conversation_store()
+            workspace_root = getattr(self.agent, "workspace_dir", None)
+            store = get_conversation_store(workspace_root)
             store.clear_session(session_id)
             logger.info(f"🗑️ Cleared dirty session data from DB: {session_id}")
         except Exception as e:

--- a/agent/registry.py
+++ b/agent/registry.py
@@ -1,0 +1,238 @@
+"""Agent profile registry.
+
+The registry is deliberately small: an agent is identified by a stable ID and
+one complete CowAgent workspace. Runtime, routing, and persistence layers build
+on this module without changing the existing single-agent configuration path.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from common.utils import expand_path
+
+
+_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class AgentRegistryError(ValueError):
+    """Raised when agent configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    """Configuration for one complete CowAgent workspace."""
+
+    id: str
+    name: str
+    workspace: str
+    enabled: bool = True
+    model: Optional[str] = None
+    bot_type: Optional[str] = None
+
+    @property
+    def workspace_path(self) -> Path:
+        return Path(self.workspace)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "workspace": self.workspace,
+            "enabled": self.enabled,
+        }
+        if self.model:
+            data["model"] = self.model
+        if self.bot_type:
+            data["bot_type"] = self.bot_type
+        return data
+
+
+def _normalise_workspace(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AgentRegistryError("agent workspace must be a non-empty string")
+    return str(Path(expand_path(value.strip())).resolve(strict=False))
+
+
+def _profile_from_mapping(raw: Mapping[str, Any]) -> AgentProfile:
+    agent_id = raw.get("id")
+    if not isinstance(agent_id, str) or not _AGENT_ID_RE.fullmatch(agent_id):
+        raise AgentRegistryError(
+            "agent id must be 1-64 URL-safe characters: letters, numbers, _ or -"
+        )
+
+    name = raw.get("name", agent_id)
+    if not isinstance(name, str) or not name.strip():
+        raise AgentRegistryError(f"agent '{agent_id}' name must be a non-empty string")
+
+    enabled = raw.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise AgentRegistryError(f"agent '{agent_id}' enabled must be a boolean")
+
+    model = raw.get("model")
+    bot_type = raw.get("bot_type")
+    for key, value in (("model", model), ("bot_type", bot_type)):
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise AgentRegistryError(
+                f"agent '{agent_id}' {key} must be a non-empty string when set"
+            )
+
+    return AgentProfile(
+        id=agent_id,
+        name=name.strip(),
+        workspace=_normalise_workspace(raw.get("workspace")),
+        enabled=enabled,
+        model=model.strip() if isinstance(model, str) else None,
+        bot_type=bot_type.strip() if isinstance(bot_type, str) else None,
+    )
+
+
+class AgentRegistry:
+    """Thread-safe registry of configured agent workspaces."""
+
+    def __init__(self, profiles: Iterable[AgentProfile], default_agent_id: str):
+        self._lock = threading.RLock()
+        self._profiles: Dict[str, AgentProfile] = {}
+        self._default_agent_id = default_agent_id
+
+        workspaces: Dict[str, str] = {}
+        for profile in profiles:
+            if profile.id in self._profiles:
+                raise AgentRegistryError(f"duplicate agent id: {profile.id}")
+            owner = workspaces.get(profile.workspace)
+            if owner is not None:
+                raise AgentRegistryError(
+                    f"agents '{owner}' and '{profile.id}' share workspace "
+                    f"'{profile.workspace}'"
+                )
+            self._profiles[profile.id] = profile
+            workspaces[profile.workspace] = profile.id
+
+        if not self._profiles:
+            raise AgentRegistryError("at least one agent profile is required")
+        self._validate_default(default_agent_id)
+
+    @classmethod
+    def from_config(cls, settings: Mapping[str, Any]) -> "AgentRegistry":
+        raw_agents = settings.get("agents")
+        if raw_agents is None or raw_agents == []:
+            workspace = settings.get("agent_workspace", "~/cow")
+            profile = AgentProfile(
+                id="default",
+                name="Default",
+                workspace=_normalise_workspace(workspace),
+            )
+            return cls([profile], "default")
+
+        if not isinstance(raw_agents, list):
+            raise AgentRegistryError("agents must be a list")
+        profiles: List[AgentProfile] = []
+        for index, raw in enumerate(raw_agents):
+            if not isinstance(raw, Mapping):
+                raise AgentRegistryError(f"agents[{index}] must be an object")
+            profiles.append(_profile_from_mapping(raw))
+
+        default_agent_id = settings.get("default_agent_id", "default")
+        if not isinstance(default_agent_id, str) or not default_agent_id:
+            raise AgentRegistryError("default_agent_id must be a non-empty string")
+        return cls(profiles, default_agent_id)
+
+    @property
+    def default_agent_id(self) -> str:
+        with self._lock:
+            return self._default_agent_id
+
+    def _validate_default(self, agent_id: str) -> None:
+        profile = self._profiles.get(agent_id)
+        if profile is None:
+            raise AgentRegistryError(f"default agent '{agent_id}' is not configured")
+        if not profile.enabled:
+            raise AgentRegistryError(f"default agent '{agent_id}' is disabled")
+
+    def get(self, agent_id: Optional[str] = None, require_enabled: bool = True) -> AgentProfile:
+        with self._lock:
+            resolved_id = agent_id or self._default_agent_id
+            profile = self._profiles.get(resolved_id)
+            if profile is None:
+                raise KeyError(resolved_id)
+            if require_enabled and not profile.enabled:
+                raise AgentRegistryError(f"agent '{resolved_id}' is disabled")
+            return profile
+
+    def get_or_default(self, agent_id: Optional[str]) -> AgentProfile:
+        with self._lock:
+            profile = self._profiles.get(agent_id) if agent_id else None
+            if profile is not None and profile.enabled:
+                return profile
+            return self._profiles[self._default_agent_id]
+
+    def list(self, include_disabled: bool = True) -> List[AgentProfile]:
+        with self._lock:
+            profiles = list(self._profiles.values())
+            if not include_disabled:
+                profiles = [profile for profile in profiles if profile.enabled]
+            return sorted(profiles, key=lambda profile: profile.id)
+
+    def upsert(self, profile: AgentProfile) -> None:
+        with self._lock:
+            for existing in self._profiles.values():
+                if existing.id != profile.id and existing.workspace == profile.workspace:
+                    raise AgentRegistryError(
+                        f"agents '{existing.id}' and '{profile.id}' share workspace "
+                        f"'{profile.workspace}'"
+                    )
+            self._profiles[profile.id] = profile
+            self._validate_default(self._default_agent_id)
+
+    def set_enabled(self, agent_id: str, enabled: bool) -> AgentProfile:
+        with self._lock:
+            current = self.get(agent_id, require_enabled=False)
+            if agent_id == self._default_agent_id and not enabled:
+                raise AgentRegistryError("the default agent cannot be disabled")
+            updated = replace(current, enabled=enabled)
+            self._profiles[agent_id] = updated
+            return updated
+
+    def set_default(self, agent_id: str) -> None:
+        with self._lock:
+            profile = self.get(agent_id, require_enabled=True)
+            self._default_agent_id = profile.id
+
+    def remove(self, agent_id: str) -> AgentProfile:
+        with self._lock:
+            if agent_id == self._default_agent_id:
+                raise AgentRegistryError("the default agent cannot be removed")
+            try:
+                return self._profiles.pop(agent_id)
+            except KeyError:
+                raise KeyError(agent_id) from None
+
+
+_registry_instance: Optional[AgentRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_agent_registry() -> AgentRegistry:
+    """Return the process-wide registry built from the current configuration."""
+
+    global _registry_instance
+    if _registry_instance is not None:
+        return _registry_instance
+    with _registry_lock:
+        if _registry_instance is None:
+            from config import conf
+
+            _registry_instance = AgentRegistry.from_config(conf())
+        return _registry_instance
+
+
+def set_agent_registry(registry: Optional[AgentRegistry]) -> None:
+    """Replace the process registry, primarily for config reloads and tests."""
+
+    global _registry_instance
+    with _registry_lock:
+        _registry_instance = registry

--- a/agent/tools/scheduler/integration.py
+++ b/agent/tools/scheduler/integration.py
@@ -4,21 +4,33 @@ Integration module for scheduler with AgentBridge
 
 import os
 import threading
-from typing import Optional
+from typing import Dict, Optional
 from config import conf
 from common.log import logger
 from common.utils import expand_path
 from bridge.context import Context, ContextType
 from bridge.reply import Reply, ReplyType
 
-# Global scheduler service instance
+# Backward-compatible aliases for the configured default agent.
 _scheduler_service = None
 _task_store = None
+_scheduler_services: Dict[str, object] = {}
+_task_stores: Dict[str, object] = {}
 # Module-level lock to guard idempotent initialization across threads
-_init_lock = threading.Lock()
+_init_lock = threading.RLock()
 
 
-def init_scheduler(agent_bridge) -> bool:
+def _resolve_workspace(workspace_root: str = None, agent_id: str = None):
+    if workspace_root is not None:
+        return os.path.realpath(expand_path(str(workspace_root)))
+    try:
+        from agent.registry import get_agent_registry
+        return get_agent_registry().get(agent_id).workspace
+    except Exception:
+        return os.path.realpath(expand_path(conf().get("agent_workspace", "~/cow")))
+
+
+def init_scheduler(agent_bridge, workspace_root: str = None, agent_id: str = None) -> bool:
     """
     Initialize scheduler service (idempotent).
 
@@ -33,28 +45,32 @@ def init_scheduler(agent_bridge) -> bool:
         True if scheduler is initialized (newly created or already running)
     """
     global _scheduler_service, _task_store
+    workspace_root = _resolve_workspace(workspace_root, agent_id)
+    agent_id = agent_bridge.agent_registry.get(agent_id).id
 
     # Fast path: already initialized and running
-    if _scheduler_service is not None and getattr(_scheduler_service, "running", False):
+    service = _scheduler_services.get(workspace_root)
+    if service is not None and getattr(service, "running", False):
         return True
 
     with _init_lock:
         # Re-check under the lock to avoid races where multiple threads
         # passed the fast-path check before any of them acquired the lock.
-        if _scheduler_service is not None and getattr(_scheduler_service, "running", False):
+        service = _scheduler_services.get(workspace_root)
+        if service is not None and getattr(service, "running", False):
             return True
 
         try:
             from agent.tools.scheduler.task_store import TaskStore
             from agent.tools.scheduler.scheduler_service import SchedulerService
 
-            # Get workspace from config
-            workspace_root = expand_path(conf().get("agent_workspace", "~/cow"))
             store_path = os.path.join(workspace_root, "scheduler", "tasks.json")
 
             # Create task store (reuse if already created)
-            if _task_store is None:
-                _task_store = TaskStore(store_path)
+            task_store = _task_stores.get(workspace_root)
+            if task_store is None:
+                task_store = TaskStore(store_path)
+                _task_stores[workspace_root] = task_store
                 logger.debug(f"[Scheduler] Task store initialized: {store_path}")
 
             # Create execute callback. Returns True on success, False to ask
@@ -76,13 +92,13 @@ def init_scheduler(agent_bridge) -> bool:
                         return False
 
                     if action_type == "agent_task":
-                        return _execute_agent_task(task, agent_bridge)
+                        return _execute_agent_task(task, agent_bridge, agent_id)
                     elif action_type == "send_message":
-                        return _execute_send_message(task, agent_bridge)
+                        return _execute_send_message(task, agent_bridge, agent_id)
                     elif action_type == "tool_call":
-                        return _execute_tool_call(task, agent_bridge)
+                        return _execute_tool_call(task, agent_bridge, agent_id)
                     elif action_type == "skill_call":
-                        return _execute_skill_call(task, agent_bridge)
+                        return _execute_skill_call(task, agent_bridge, agent_id)
                     else:
                         logger.warning(f"[Scheduler] Unknown action type: {action_type}")
                         return True
@@ -91,10 +107,17 @@ def init_scheduler(agent_bridge) -> bool:
                     return False
 
             # Create scheduler service
-            _scheduler_service = SchedulerService(_task_store, execute_task_callback)
-            _scheduler_service.start()
+            service = SchedulerService(task_store, execute_task_callback)
+            service.start()
+            _scheduler_services[workspace_root] = service
+            if agent_id == agent_bridge.agent_registry.default_agent_id:
+                _scheduler_service = service
+                _task_store = task_store
 
-            logger.info("[Scheduler] Service initialized and started")
+            logger.info(
+                f"[Scheduler] Service initialized for agent={agent_id}, "
+                f"workspace={workspace_root}"
+            )
             return True
 
         except Exception as e:
@@ -136,14 +159,32 @@ def _is_channel_ready(channel_type: str, receiver: str) -> bool:
         return True
 
 
-def get_task_store():
-    """Get the global task store instance"""
-    return _task_store
+def get_task_store(workspace_root: str = None, agent_id: str = None):
+    """Get the task store owned by one agent workspace."""
+    workspace_root = _resolve_workspace(workspace_root, agent_id)
+    return _task_stores.get(workspace_root)
 
 
-def get_scheduler_service():
-    """Get the global scheduler service instance"""
-    return _scheduler_service
+def get_scheduler_service(workspace_root: str = None, agent_id: str = None):
+    """Get the scheduler service owned by one agent workspace."""
+    workspace_root = _resolve_workspace(workspace_root, agent_id)
+    return _scheduler_services.get(workspace_root)
+
+
+def reset_scheduler_services(stop: bool = True) -> None:
+    """Stop and forget all scheduler services, primarily for reloads/tests."""
+    global _scheduler_service, _task_store
+    with _init_lock:
+        if stop:
+            for service in list(_scheduler_services.values()):
+                try:
+                    service.stop()
+                except Exception:
+                    pass
+        _scheduler_services.clear()
+        _task_stores.clear()
+        _scheduler_service = None
+        _task_store = None
 
 
 def _remember_delivered_output(
@@ -151,6 +192,7 @@ def _remember_delivered_output(
     task: dict,
     channel_type: str,
     content: str,
+    agent_id: str = None,
 ) -> None:
     """Best-effort persistence of the message the scheduler sent to a user.
 
@@ -182,14 +224,20 @@ def _remember_delivered_output(
         remember = getattr(agent_bridge, "remember_scheduled_output", None)
         if remember:
             task_desc = action.get("task_description") or action.get("content", "")
-            remember(session_id, str(content), channel_type=channel_type, task_description=task_desc)
+            kwargs = {
+                "channel_type": channel_type,
+                "task_description": task_desc,
+            }
+            if hasattr(agent_bridge, "agent_registry"):
+                kwargs["agent_id"] = agent_id
+            remember(session_id, str(content), **kwargs)
     except Exception as e:
         logger.warning(
             f"[Scheduler] Failed to remember delivered output for {session_id}: {e}"
         )
 
 
-def _execute_agent_task(task: dict, agent_bridge) -> bool:
+def _execute_agent_task(task: dict, agent_bridge, agent_id: str = None) -> bool:
     """
     Execute an agent_task action - let Agent handle the task.
     Returns True on successful delivery, False to retry next tick.
@@ -224,6 +272,7 @@ def _execute_agent_task(task: dict, agent_bridge) -> bool:
         context["receiver"] = receiver
         context["isgroup"] = is_group
         context["session_id"] = scheduler_session_id
+        context["agent_id"] = agent_id
         
         # Channel-specific setup
         if channel_type == "web":
@@ -278,7 +327,9 @@ def _execute_agent_task(task: dict, agent_bridge) -> bool:
                 logger.error(f"[Scheduler] Failed to send result: {e}")
                 return False
 
-            _remember_delivered_output(agent_bridge, task, channel_type, reply.content)
+            _remember_delivered_output(
+                agent_bridge, task, channel_type, reply.content, agent_id
+            )
             logger.info(f"[Scheduler] Task {task['id']} executed successfully, result sent to {receiver}")
             return True
 
@@ -295,7 +346,7 @@ def _execute_agent_task(task: dict, agent_bridge) -> bool:
         return False
 
 
-def _execute_send_message(task: dict, agent_bridge) -> bool:
+def _execute_send_message(task: dict, agent_bridge, agent_id: str = None) -> bool:
     """Execute a send_message action. Returns True/False for delivery."""
     try:
         action = task.get("action", {})
@@ -313,6 +364,7 @@ def _execute_send_message(task: dict, agent_bridge) -> bool:
         context["receiver"] = receiver
         context["isgroup"] = is_group
         context["session_id"] = receiver
+        context["agent_id"] = agent_id
         
         # Channel-specific context setup
         if channel_type == "web":
@@ -365,7 +417,9 @@ def _execute_send_message(task: dict, agent_bridge) -> bool:
             logger.error(f"[Scheduler] Failed to send message: {e}")
             return False
 
-        _remember_delivered_output(agent_bridge, task, channel_type, content)
+        _remember_delivered_output(
+            agent_bridge, task, channel_type, content, agent_id
+        )
         logger.info(f"[Scheduler] Task {task['id']} executed: sent message to {receiver}")
         return True
 
@@ -376,7 +430,7 @@ def _execute_send_message(task: dict, agent_bridge) -> bool:
         return False
 
 
-def _execute_tool_call(task: dict, agent_bridge) -> bool:
+def _execute_tool_call(task: dict, agent_bridge, agent_id: str = None) -> bool:
     """Execute a tool_call action. Returns True/False for delivery."""
     try:
         action = task.get("action", {})
@@ -410,6 +464,7 @@ def _execute_tool_call(task: dict, agent_bridge) -> bool:
         context["receiver"] = receiver
         context["isgroup"] = is_group
         context["session_id"] = receiver
+        context["agent_id"] = agent_id
 
         request_id = None
         if channel_type == "web":
@@ -439,7 +494,9 @@ def _execute_tool_call(task: dict, agent_bridge) -> bool:
             logger.error(f"[Scheduler] Failed to send tool result: {e}")
             return False
 
-        _remember_delivered_output(agent_bridge, task, channel_type, content)
+        _remember_delivered_output(
+            agent_bridge, task, channel_type, content, agent_id
+        )
         logger.info(f"[Scheduler] Task {task['id']} executed: sent tool result to {receiver}")
         return True
 
@@ -448,7 +505,7 @@ def _execute_tool_call(task: dict, agent_bridge) -> bool:
         return False
 
 
-def _execute_skill_call(task: dict, agent_bridge) -> bool:
+def _execute_skill_call(task: dict, agent_bridge, agent_id: str = None) -> bool:
     """Execute a skill_call action by asking Agent to run the skill.
     Returns True/False for delivery."""
     try:
@@ -479,6 +536,7 @@ def _execute_skill_call(task: dict, agent_bridge) -> bool:
         context["receiver"] = receiver
         context["isgroup"] = is_group
         context["session_id"] = scheduler_session_id
+        context["agent_id"] = agent_id
 
         if channel_type == "web":
             import uuid
@@ -523,7 +581,9 @@ def _execute_skill_call(task: dict, agent_bridge) -> bool:
             logger.error(f"[Scheduler] Failed to send skill result: {e}")
             return False
 
-        _remember_delivered_output(agent_bridge, task, channel_type, content)
+        _remember_delivered_output(
+            agent_bridge, task, channel_type, content, agent_id
+        )
         logger.info(f"[Scheduler] Task {task['id']} executed: skill result sent to {receiver}")
         return True
 
@@ -542,10 +602,14 @@ def attach_scheduler_to_tool(tool, context: Context = None):
         tool: SchedulerTool instance
         context: Current context (optional)
     """
-    if _task_store:
-        tool.task_store = _task_store
-    
     if context:
+        agent_id = context.get("agent_id")
+        task_store = get_task_store(agent_id=agent_id)
+        scheduler_service = get_scheduler_service(agent_id=agent_id)
+        if task_store:
+            tool.task_store = task_store
+        if scheduler_service:
+            tool.scheduler_service = scheduler_service
         tool.current_context = context
         
         channel_type = context.get("channel_type") or conf().get("channel_type", "unknown")

--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -294,6 +294,7 @@ class AgentBridge:
         self.default_agent = None
         self.agent: Optional[Agent] = None
         self.scheduler_initialized = False
+        self.scheduler_agent_ids = set()
         
         # Create helper instances
         self.initializer = AgentInitializer(bridge, self)
@@ -302,8 +303,10 @@ class AgentBridge:
         # for the first user message. init_scheduler is idempotent.
         try:
             from agent.tools.scheduler.integration import init_scheduler
-            if init_scheduler(self):
-                self.scheduler_initialized = True
+            for profile in self.agent_registry.list(include_disabled=False):
+                if init_scheduler(self, profile.workspace, profile.id):
+                    self.scheduler_agent_ids.add(profile.id)
+            self.scheduler_initialized = bool(self.scheduler_agent_ids)
         except Exception as e:
             logger.warning(f"[AgentBridge] Eager scheduler init failed: {e}")
 
@@ -373,6 +376,12 @@ class AgentBridge:
     
     def _resolve_agent_id(self, agent_id: str = None) -> str:
         return self.agent_registry.get(agent_id).id
+
+    def get_conversation_store(self, agent_id: str = None):
+        """Return the session store owned by one agent workspace."""
+        profile = self.agent_registry.get(agent_id)
+        from agent.memory import get_conversation_store
+        return get_conversation_store(profile.workspace)
 
     @staticmethod
     def _runtime_key(agent_id: str, session_id: str) -> Tuple[str, str]:
@@ -462,8 +471,7 @@ class AgentBridge:
         if not (hasattr(agent, "messages") and hasattr(agent, "messages_lock")):
             return -1
         try:
-            from agent.memory import get_conversation_store
-            store = get_conversation_store()
+            store = self.get_conversation_store(agent_id)
             # No turn cap here: we want a faithful mirror of what the store
             # has for this session after deletion.
             remaining = store.load_messages(session_id, max_turns=10**6)
@@ -586,7 +594,7 @@ class AgentBridge:
             # The reply (assistant/tool messages) is appended once the run
             # completes; the final persist skips this already-stored user turn.
             pre_persisted = self._pre_persist_user_message(
-                session_id, query, context, clear_history
+                session_id, query, context, clear_history, resolved_agent_id
             )
 
             # Mark this session as mid-run so the self-evolution idle scan does
@@ -637,14 +645,20 @@ class AgentBridge:
                 if pre_persisted and new_messages and new_messages[0].get("role") == "user":
                     new_messages = new_messages[1:]
                 if new_messages:
-                    self._persist_messages(session_id, list(new_messages), channel_type)
+                    self._persist_messages(
+                        session_id,
+                        list(new_messages),
+                        channel_type,
+                        resolved_agent_id,
+                    )
                 else:
                     with agent.messages_lock:
                         msg_count = len(agent.messages)
                     if msg_count == 0:
                         try:
-                            from agent.memory import get_conversation_store
-                            get_conversation_store().clear_session(session_id)
+                            self.get_conversation_store(
+                                resolved_agent_id
+                            ).clear_session(session_id)
                             logger.info(f"[AgentBridge] Cleared DB for recovered session: {session_id}")
                         except Exception as e:
                             logger.warning(f"[AgentBridge] Failed to clear DB after recovery: {e}")
@@ -697,8 +711,9 @@ class AgentBridge:
                     with agent.messages_lock:
                         msg_count = len(agent.messages)
                     if msg_count == 0:
-                        from agent.memory import get_conversation_store
-                        get_conversation_store().clear_session(session_id)
+                        self.get_conversation_store(
+                            resolved_agent_id
+                        ).clear_session(session_id)
                         logger.info(f"[AgentBridge] Cleared DB for session after error: {session_id}")
                 except Exception as db_err:
                     logger.warning(f"[AgentBridge] Failed to clear DB after error: {db_err}")
@@ -862,7 +877,12 @@ class AgentBridge:
                 logger.warning(f"[AgentBridge] Failed to sync API keys: {e}")
     
     def _pre_persist_user_message(
-        self, session_id: str, query: str, context: Context, clear_history: bool
+        self,
+        session_id: str,
+        query: str,
+        context: Context,
+        clear_history: bool,
+        agent_id: str = None,
     ) -> bool:
         """Persist the user's message before the agent runs.
 
@@ -884,8 +904,7 @@ class AgentBridge:
             from config import conf
             if not conf().get("conversation_persistence", True):
                 return False
-            from agent.memory import get_conversation_store
-            store = get_conversation_store()
+            store = self.get_conversation_store(agent_id)
             # clear_history starts a fresh transcript: wipe the store first so
             # the eager user turn becomes seq 0, matching in-memory state.
             if clear_history:
@@ -904,7 +923,11 @@ class AgentBridge:
             return False
 
     def _persist_messages(
-        self, session_id: str, new_messages: list, channel_type: str = ""
+        self,
+        session_id: str,
+        new_messages: list,
+        channel_type: str = "",
+        agent_id: str = None,
     ) -> None:
         """
         Persist new messages to the conversation store after each agent run.
@@ -930,8 +953,7 @@ class AgentBridge:
             messages_to_store = self._strip_thinking_blocks(new_messages)
 
         try:
-            from agent.memory import get_conversation_store
-            get_conversation_store().append_messages(
+            self.get_conversation_store(agent_id).append_messages(
                 session_id, messages_to_store, channel_type=channel_type
             )
         except Exception as e:
@@ -992,12 +1014,11 @@ class AgentBridge:
 
         # Persist first so the new pair gets a stable seq, then prune old
         # scheduler pairs in DB, then sync the in-memory agent.messages buffer.
-        self._persist_messages(session_id, messages, channel_type)
+        self._persist_messages(session_id, messages, channel_type, agent_id)
 
         keep_last_n = max(int(conf().get("scheduler_inject_max_per_session", 3) or 0), 0)
         try:
-            from agent.memory import get_conversation_store
-            deleted = get_conversation_store().prune_scheduled_messages(
+            deleted = self.get_conversation_store(agent_id).prune_scheduled_messages(
                 session_id, keep_last_n=keep_last_n
             )
             if deleted:

--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -3,7 +3,8 @@ Agent Bridge - Integrates Agent system with existing COW bridge
 """
 
 import os
-from typing import Optional, List
+import threading
+from typing import Dict, Iterator, Optional, List, Tuple
 
 from agent.protocol import Agent, LLMModel, LLMRequest, get_cancel_registry
 from bridge.agent_event_handler import AgentEventHandler
@@ -279,8 +280,18 @@ class AgentBridge:
     
     def __init__(self, bridge: Bridge):
         self.bridge = bridge
-        self.agents = {}  # session_id -> Agent instance mapping
-        self.default_agent = None  # For backward compatibility (no session_id)
+        from agent.registry import get_agent_registry
+
+        self.agent_registry = get_agent_registry()
+        # Canonical runtime map. A session identifier is only unique inside an
+        # agent workspace, so the agent id is part of every live key.
+        self._agent_instances: Dict[Tuple[str, str], Agent] = {}
+        self._default_agents: Dict[str, Agent] = {}
+        self._agents_lock = threading.RLock()
+        # Backward-compatible view for integrations that inspect sessions of
+        # the configured default agent directly.
+        self.agents: Dict[str, Agent] = {}
+        self.default_agent = None
         self.agent: Optional[Agent] = None
         self.scheduler_initialized = False
         
@@ -360,39 +371,77 @@ class AgentBridge:
 
         return agent
     
-    def get_agent(self, session_id: str = None) -> Optional[Agent]:
+    def _resolve_agent_id(self, agent_id: str = None) -> str:
+        return self.agent_registry.get(agent_id).id
+
+    @staticmethod
+    def _runtime_key(agent_id: str, session_id: str) -> Tuple[str, str]:
+        return agent_id, session_id
+
+    @staticmethod
+    def _cancel_key(agent_id: str, token: str, default_agent_id: str) -> str:
+        """Keep legacy token keys for the default agent, namespace the rest."""
+        return token if agent_id == default_agent_id else f"{agent_id}::{token}"
+
+    def get_agent(self, session_id: str = None, agent_id: str = None) -> Optional[Agent]:
         """
         Get agent instance for the given session
         
         Args:
-            session_id: Session identifier (e.g., user_id). If None, returns default agent.
+            session_id: Session identifier (e.g., user_id). If None, returns
+                the workspace's default runtime instance.
+            agent_id: Agent profile identifier. Omit for the configured default.
         
         Returns:
             Agent instance for this session
         """
-        # If no session_id, use default agent (backward compatibility)
-        if session_id is None:
-            if self.default_agent is None:
-                self._init_default_agent()
-            return self.default_agent
-        
-        # Check if agent exists for this session
-        if session_id not in self.agents:
-            self._init_agent_for_session(session_id)
-        
-        return self.agents[session_id]
-    
-    def _init_default_agent(self):
-        """Initialize default super agent"""
-        agent = self.initializer.initialize_agent(session_id=None)
-        self.default_agent = agent
-    
-    def _init_agent_for_session(self, session_id: str):
-        """Initialize agent for a specific session"""
-        agent = self.initializer.initialize_agent(session_id=session_id)
-        self.agents[session_id] = agent
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        with self._agents_lock:
+            if session_id is None:
+                agent = self._default_agents.get(resolved_agent_id)
+                if agent is None:
+                    agent = self.initializer.initialize_agent(
+                        session_id=None, agent_id=resolved_agent_id
+                    )
+                    self._default_agents[resolved_agent_id] = agent
+                if resolved_agent_id == self.agent_registry.default_agent_id:
+                    self.default_agent = agent
+                return agent
 
-    def sync_session_messages_from_store(self, session_id: str) -> int:
+            key = self._runtime_key(resolved_agent_id, session_id)
+            agent = self._agent_instances.get(key)
+            if agent is None:
+                agent = self.initializer.initialize_agent(
+                    session_id=session_id, agent_id=resolved_agent_id
+                )
+                self._agent_instances[key] = agent
+                if resolved_agent_id == self.agent_registry.default_agent_id:
+                    self.agents[session_id] = agent
+            return agent
+
+    def get_cached_agent(self, session_id: str, agent_id: str = None) -> Optional[Agent]:
+        """Return an existing session agent without creating one."""
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        with self._agents_lock:
+            return self._agent_instances.get(
+                self._runtime_key(resolved_agent_id, session_id)
+            )
+
+    def iter_agent_instances(
+        self, include_defaults: bool = True
+    ) -> Iterator[Tuple[str, Optional[str], Agent]]:
+        """Snapshot all live instances as ``(agent_id, session_id, agent)``."""
+        with self._agents_lock:
+            defaults = list(self._default_agents.items()) if include_defaults else []
+            sessions = list(self._agent_instances.items())
+        for agent_id, agent in defaults:
+            yield agent_id, None, agent
+        for (agent_id, session_id), agent in sessions:
+            yield agent_id, session_id, agent
+
+    def sync_session_messages_from_store(
+        self, session_id: str, agent_id: str = None
+    ) -> int:
         """Reload an agent's in-memory ``messages`` list from the persistent
         conversation store.
 
@@ -405,9 +454,11 @@ class AgentBridge:
             Number of messages now held in the agent's memory. Returns -1 if
             the agent does not exist or has no compatible ``messages`` attr.
         """
-        if not session_id or session_id not in self.agents:
+        if not session_id:
             return -1
-        agent = self.agents[session_id]
+        agent = self.get_cached_agent(session_id, agent_id=agent_id)
+        if agent is None:
+            return -1
         if not (hasattr(agent, "messages") and hasattr(agent, "messages_lock")):
             return -1
         try:
@@ -449,14 +500,19 @@ class AgentBridge:
             Reply object
         """
         session_id = None
+        agent_id = None
         agent = None
         request_id = None
         cancel_event = None
+        token_key = None
         try:
             # Extract session_id from context for user isolation
             if context:
                 session_id = context.kwargs.get("session_id") or context.get("session_id")
+                agent_id = context.kwargs.get("agent_id") or context.get("agent_id")
                 request_id = context.kwargs.get("request_id") or context.get("request_id")
+
+            resolved_agent_id = self._resolve_agent_id(agent_id)
 
             # Register a cancel token. Prefer per-turn request_id (web),
             # fall back to session_id (IM channels). The Event is polled by
@@ -464,10 +520,17 @@ class AgentBridge:
             registry = get_cancel_registry()
             token_key = request_id or session_id
             if token_key:
+                token_key = self._cancel_key(
+                    resolved_agent_id,
+                    token_key,
+                    self.agent_registry.default_agent_id,
+                )
                 cancel_event = registry.register(token_key, session_id=session_id)
 
             # Get agent for this session (will auto-initialize if needed)
-            agent = self.get_agent(session_id=session_id)
+            agent = self.get_agent(
+                session_id=session_id, agent_id=resolved_agent_id
+            )
             if not agent:
                 return Reply(ReplyType.ERROR, "Failed to initialize super agent")
             
@@ -499,9 +562,11 @@ class AgentBridge:
             if context and hasattr(agent, 'model'):
                 agent.model.channel_type = context.get("channel_type", "")
                 agent.model.session_id = session_id or ""
+                agent.model.agent_id = resolved_agent_id
 
             # Store session_id on agent so executor can clear DB on fatal errors
             agent._current_session_id = session_id
+            agent._current_agent_id = resolved_agent_id
 
             # Bound the in-memory context for scheduler sessions before each run.
             # Scheduler sessions are stable per-task and append every trigger,
@@ -638,9 +703,9 @@ class AgentBridge:
                 except Exception as db_err:
                     logger.warning(f"[AgentBridge] Failed to clear DB after error: {db_err}")
             # Release cancel token on error path too (idempotent).
-            if cancel_event is not None and (request_id or session_id):
+            if cancel_event is not None and token_key:
                 try:
-                    get_cancel_registry().unregister(request_id or session_id)
+                    get_cancel_registry().unregister(token_key)
                 except Exception:
                     pass
             return Reply(ReplyType.ERROR, f"Agent error: {str(e)}")
@@ -887,6 +952,7 @@ class AgentBridge:
         content: str,
         channel_type: str = "",
         task_description: str = "",
+        agent_id: str = None,
     ) -> None:
         """Add the visible output of a scheduled task to the receiver's session.
 
@@ -945,7 +1011,7 @@ class AgentBridge:
                 f"for session={session_id}: {e}"
             )
 
-        agent = self.agents.get(session_id)
+        agent = self.get_cached_agent(session_id, agent_id=agent_id)
         if agent:
             try:
                 with agent.messages_lock:
@@ -1091,22 +1157,49 @@ class AgentBridge:
                 cleaned.append(new_msg)
         return cleaned
 
-    def clear_session(self, session_id: str):
+    def clear_session(self, session_id: str, agent_id: str = None):
         """
         Clear a specific session's agent and conversation history
         
         Args:
             session_id: Session identifier to clear
         """
-        if session_id in self.agents:
-            logger.info(f"[AgentBridge] Clearing session: {session_id}")
-            del self.agents[session_id]
+        if not session_id:
+            return
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        key = self._runtime_key(resolved_agent_id, session_id)
+        with self._agents_lock:
+            removed = self._agent_instances.pop(key, None)
+            if resolved_agent_id == self.agent_registry.default_agent_id:
+                self.agents.pop(session_id, None)
+        if removed is not None:
+            logger.info(
+                f"[AgentBridge] Clearing session: agent={resolved_agent_id}, "
+                f"session={session_id}"
+            )
+
+    def clear_agent(self, agent_id: str) -> int:
+        """Evict every live runtime instance for one agent workspace."""
+        resolved_agent_id = self._resolve_agent_id(agent_id)
+        with self._agents_lock:
+            keys = [key for key in self._agent_instances if key[0] == resolved_agent_id]
+            for key in keys:
+                self._agent_instances.pop(key, None)
+            self._default_agents.pop(resolved_agent_id, None)
+            if resolved_agent_id == self.agent_registry.default_agent_id:
+                self.agents.clear()
+                self.default_agent = None
+        return len(keys)
     
     def clear_all_sessions(self):
         """Clear all agent sessions"""
-        logger.info(f"[AgentBridge] Clearing all sessions ({len(self.agents)} total)")
-        self.agents.clear()
-        self.default_agent = None
+        with self._agents_lock:
+            count = len(self._agent_instances)
+            logger.info(f"[AgentBridge] Clearing all sessions ({count} total)")
+            self._agent_instances.clear()
+            self._default_agents.clear()
+            self.agents.clear()
+            self.default_agent = None
     
     def refresh_all_skills(self) -> int:
         """
@@ -1120,24 +1213,18 @@ class AgentBridge:
         from dotenv import load_dotenv
         from config import conf
 
-        # Reload environment variables from .env file
-        workspace_root = expand_path(conf().get("agent_workspace", "~/cow"))
-        env_file = os.path.join(workspace_root, '.env')
-
-        if os.path.exists(env_file):
-            load_dotenv(env_file, override=True)
-            logger.info(f"[AgentBridge] Reloaded environment variables from {env_file}")
-
         refreshed_count = 0
+        loaded_env_files = set()
 
-        # Collect all agent instances to refresh
-        agents_to_refresh = []
-        if self.default_agent:
-            agents_to_refresh.append(("default", self.default_agent))
-        for session_id, agent in self.agents.items():
-            agents_to_refresh.append((session_id, agent))
-
-        for label, agent in agents_to_refresh:
+        for agent_id, session_id, agent in self.iter_agent_instances():
+            workspace_root = getattr(agent, "workspace_dir", None)
+            env_file = os.path.join(workspace_root, ".env") if workspace_root else None
+            if env_file and env_file not in loaded_env_files and os.path.exists(env_file):
+                load_dotenv(env_file, override=True)
+                loaded_env_files.add(env_file)
+                logger.info(
+                    f"[AgentBridge] Reloaded environment variables from {env_file}"
+                )
             # Refresh skills
             if hasattr(agent, 'skill_manager') and agent.skill_manager:
                 agent.skill_manager.refresh_skills()

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -78,7 +78,9 @@ class AgentInitializer:
         tools = self._load_tools(workspace_root, memory_manager, memory_tools, session_id)
         
         # Initialize scheduler if needed
-        self._initialize_scheduler(tools, session_id)
+        self._initialize_scheduler(
+            tools, session_id, workspace_root=workspace_root, agent_id=profile.id
+        )
         
         # Load context files
         context_files = load_context_files(workspace_root)
@@ -157,7 +159,7 @@ class AgentInitializer:
 
         try:
             from agent.memory import get_conversation_store
-            store = get_conversation_store()
+            store = get_conversation_store(agent.workspace_dir)
             max_turns = conf().get("agent_max_context_turns", 20)
             # Scheduler tasks run on a stable isolated session per task and
             # can fire many times a day; a smaller restore window keeps prompt
@@ -415,34 +417,52 @@ class AgentInitializer:
         
         return tools
     
-    def _initialize_scheduler(self, tools: List, session_id: Optional[str] = None):
+    def _initialize_scheduler(
+        self,
+        tools: List,
+        session_id: Optional[str] = None,
+        workspace_root: str = None,
+        agent_id: str = None,
+    ):
         """Initialize scheduler service if needed.
 
         Serialize the check-and-set under a module-level lock so concurrent
         first-time session inits cannot each create a new SchedulerService
         (which would leak background scanning threads).
         """
-        if not self.agent_bridge.scheduler_initialized:
+        if agent_id not in self.agent_bridge.scheduler_agent_ids:
             with _scheduler_init_lock:
-                if not self.agent_bridge.scheduler_initialized:
+                if agent_id not in self.agent_bridge.scheduler_agent_ids:
                     try:
                         from agent.tools.scheduler.integration import init_scheduler
-                        if init_scheduler(self.agent_bridge):
+                        if init_scheduler(
+                            self.agent_bridge,
+                            workspace_root=workspace_root,
+                            agent_id=agent_id,
+                        ):
+                            self.agent_bridge.scheduler_agent_ids.add(agent_id)
                             self.agent_bridge.scheduler_initialized = True
                             if session_id is None:
-                                logger.info("[AgentInitializer] Scheduler service initialized")
+                                logger.info(
+                                    f"[AgentInitializer] Scheduler initialized "
+                                    f"for agent={agent_id}"
+                                )
                     except Exception as e:
                         logger.warning(f"[AgentInitializer] Failed to initialize scheduler: {e}")
         
         # Inject scheduler dependencies
-        if self.agent_bridge.scheduler_initialized:
+        if agent_id in self.agent_bridge.scheduler_agent_ids:
             try:
                 from agent.tools.scheduler.integration import get_task_store, get_scheduler_service
                 from agent.tools import SchedulerTool
                 from config import conf
                 
-                task_store = get_task_store()
-                scheduler_service = get_scheduler_service()
+                task_store = get_task_store(
+                    workspace_root=workspace_root, agent_id=agent_id
+                )
+                scheduler_service = get_scheduler_service(
+                    workspace_root=workspace_root, agent_id=agent_id
+                )
                 
                 for tool in tools:
                     if isinstance(tool, SchedulerTool):
@@ -458,6 +478,7 @@ class AgentInitializer:
                         else:
                             ct = raw_ct
                         tool.config["channel_type"] = ct
+                        tool.config["agent_id"] = agent_id
             except Exception as e:
                 logger.warning(f"[AgentInitializer] Failed to inject scheduler dependencies: {e}")
     
@@ -630,11 +651,14 @@ class AgentInitializer:
         # Phase 1: flush daily summaries
         flushed = 0
         flush_threads = []
-        dream_candidate = None
+        dream_candidates = {}
         for label, agent in agents:
             try:
                 if not agent.memory_manager:
                     continue
+                dream_candidates.setdefault(
+                    agent.agent_id, agent.memory_manager.flush_manager
+                )
                 with agent.messages_lock:
                     messages = list(agent.messages)
                 if not messages:
@@ -645,8 +669,6 @@ class AgentInitializer:
                     t = agent.memory_manager.flush_manager._last_flush_thread
                     if t:
                         flush_threads.append(t)
-                if dream_candidate is None:
-                    dream_candidate = agent.memory_manager.flush_manager
             except Exception as e:
                 logger.warning(f"[DailyFlush] Failed for session {label}: {e}")
 
@@ -658,10 +680,13 @@ class AgentInitializer:
             t.join(timeout=60)
 
         # Phase 2: Deep Dream — distill daily memories → MEMORY.md + dream diary
-        if dream_candidate:
+        for agent_id, dream_candidate in dream_candidates.items():
             try:
                 result = dream_candidate.deep_dream()
                 if result:
-                    logger.info("[DeepDream] Memory distillation completed successfully")
+                    logger.info(
+                        f"[DeepDream] Memory distillation completed for "
+                        f"agent={agent_id}"
+                    )
             except Exception as e:
-                logger.warning(f"[DeepDream] Failed: {e}")
+                logger.warning(f"[DeepDream] Failed for agent={agent_id}: {e}")

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -38,20 +38,25 @@ class AgentInitializer:
         self.bridge = bridge
         self.agent_bridge = agent_bridge
     
-    def initialize_agent(self, session_id: Optional[str] = None) -> Agent:
+    def initialize_agent(
+        self,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Agent:
         """
         Initialize agent for a session
         
         Args:
             session_id: Session ID (None for default agent)
+            agent_id: Agent profile identifier. Omit for the configured default.
         
         Returns:
             Initialized agent instance
         """
         from config import conf
-        
-        # Get workspace from config
-        workspace_root = expand_path(conf().get("agent_workspace", "~/cow"))
+
+        profile = self.agent_bridge.agent_registry.get(agent_id)
+        workspace_root = profile.workspace
         
         # Migrate API keys
         self._migrate_config_to_env(workspace_root)
@@ -84,6 +89,8 @@ class AgentInitializer:
         # Build system prompt
         prompt_builder = PromptBuilder(workspace_dir=workspace_root, language="zh")
         runtime_info = self._get_runtime_info(workspace_root)
+        runtime_info["agent_id"] = profile.id
+        runtime_info["agent_name"] = profile.name
         
         system_prompt = prompt_builder.build(
             tools=tools,
@@ -116,6 +123,10 @@ class AgentInitializer:
             agent.memory_manager = memory_manager
             if hasattr(agent, 'model') and agent.model:
                 memory_manager.flush_manager.llm_model = agent.model
+
+        agent.agent_id = profile.id
+        agent.agent_profile = profile
+        agent.workspace_dir = workspace_root
 
         # Restore persisted conversation history for this session
         if session_id:
@@ -608,11 +619,10 @@ class AgentInitializer:
 
     def _flush_all_agents(self):
         """Flush memory for all active agent sessions, then run Deep Dream."""
-        agents = []
-        if self.agent_bridge.default_agent:
-            agents.append(("default", self.agent_bridge.default_agent))
-        for sid, agent in self.agent_bridge.agents.items():
-            agents.append((sid, agent))
+        agents = [
+            (f"{agent_id}:{session_id or 'default'}", agent)
+            for agent_id, session_id, agent in self.agent_bridge.iter_agent_instances()
+        ]
 
         if not agents:
             return

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -4759,9 +4759,7 @@ class SessionDetailHandler:
             try:
                 from bridge.bridge import Bridge
                 ab = Bridge().get_agent_bridge()
-                if session_id in ab.agents:
-                    del ab.agents[session_id]
-                    logger.info(f"[WebChannel] Removed agent instance for session {session_id}")
+                ab.clear_session(session_id)
             except Exception:
                 pass
 
@@ -4840,9 +4838,7 @@ class SessionClearContextHandler:
                 from bridge.bridge import Bridge
                 bridge = Bridge()
                 ab = bridge.get_agent_bridge()
-                if session_id in ab.agents:
-                    del ab.agents[session_id]
-                    logger.info(f"[WebChannel] Cleared agent instance for session {session_id}")
+                ab.clear_session(session_id)
             except Exception:
                 pass
 

--- a/config.py
+++ b/config.py
@@ -257,6 +257,12 @@ available_setting = {
     "mcp_oauth_redirect_base": "",  # Base URL for MCP OAuth callback (e.g. http://your-ip:9899); empty uses local web console
     "agent": True,  # whether to enable Agent mode
     "agent_workspace": "~/cow",  # agent workspace path, used to store skills, memory, etc.
+    # Optional native multi-agent registry. When empty or omitted, CowAgent
+    # synthesizes one "default" agent from agent_workspace and behaves exactly
+    # as before. Each configured workspace is a complete CowAgent workspace.
+    "agents": [],
+    "default_agent_id": "default",
+    "agent_bindings": [],
     "agent_max_context_tokens": 50000,  # max context tokens in Agent mode
     "agent_max_context_turns": 20,  # max context memory turns in Agent mode
     "agent_max_steps": 20,  # max decision steps per run in Agent mode

--- a/docs/superpowers/plans/2026-07-19-native-multi-agent-implementation.md
+++ b/docs/superpowers/plans/2026-07-19-native-multi-agent-implementation.md
@@ -1,0 +1,86 @@
+# Native Multi-Agent Implementation Plan
+
+## Change 1: Agent registry
+
+- Add immutable `AgentProfile` values and a thread-safe `AgentRegistry`.
+- Parse `agents`, `default_agent_id`, and `agent_bindings` from configuration.
+- Synthesize the default profile from `agent_workspace` when the new fields are
+  absent.
+- Validate IDs, duplicate workspaces, enabled defaults, and binding targets.
+- Add unit tests for compatibility and invalid configurations.
+
+Verification: registry tests, configuration tests, Python compilation.
+
+## Change 2: Runtime isolation
+
+- Thread `agent_id` through `AgentBridge`, `AgentInitializer`, and chat service.
+- Key live agent instances by `(agent_id, session_id)`.
+- Pass the resolved workspace explicitly to prompt, tools, skills, memory, and
+  runtime metadata.
+- Add eviction helpers for one agent and one agent session.
+- Test same-session isolation and legacy callers.
+
+Verification: bridge/initializer tests and existing agent tests.
+
+## Change 3: Workspace-scoped state
+
+- Replace memory and conversation process singletons with workspace registries.
+- Replace scheduler singleton access with workspace-scoped services and stores.
+- Scope flush, Deep Dream, evolution, session operations, and task execution to
+  the owning workspace.
+- Keep the existing database schema and file layout.
+- Test independent databases, tasks, timers, and cleanup.
+
+Verification: memory, conversation, scheduler, evolution, and regression tests.
+
+## Change 4: Routing
+
+- Add a binding resolver with exact, channel-default, and global-default
+  precedence.
+- Add `agent_id` to inbound contexts and preserve it through queues, replies,
+  persistence, and cancellation.
+- Add Web chat agent selection.
+- Test private chats, groups, missing targets, disabled targets, and unchanged
+  default routing.
+
+Verification: routing and representative channel tests.
+
+## Change 5: Web management
+
+- Add authenticated APIs for agent CRUD, bindings, and allowed core files.
+- Use atomic writes, path containment checks, and content revisions.
+- Add an Agents page and selectors in chat, sessions, tasks, memory, skills, and
+  knowledge views where relevant.
+- Evict only the affected agent after core-file changes.
+- Test API authorization, validation, traversal protection, conflicts, and UI
+  production build.
+
+Verification: API tests, TypeScript checks, and desktop production build.
+
+## Change 6: Delegation
+
+- Add a delegation service and `agent_delegate` tool.
+- Create stable target relay sessions without user-channel delivery.
+- Enforce target policy, timeout, cancellation, depth, cycle, size, and
+  concurrency limits.
+- Return structured provenance and errors.
+- Test success, unavailable targets, timeout, cancellation, and cycles.
+
+Verification: delegation tests and agent tool regressions.
+
+## Change 7: Backup and hardening
+
+- Extend the backup manifest with registry, bindings, and selected workspaces.
+- Preserve archive traversal, destination, and rollback protections.
+- Add single-agent and all-agent backup/restore tests.
+- Update English, Chinese, and Japanese documentation.
+- Run the complete Python suite and desktop build against the final stack.
+
+Verification: backup tests, full Python suite, desktop build, and diff checks.
+
+## Publication
+
+- Preserve one branch pointer after each ordered change.
+- Push all implementation branches only after the final stack passes.
+- Open reviewable pull requests with explicit dependency notes and validation.
+- Open one tracking issue describing the completed work and merge order.

--- a/docs/superpowers/specs/2026-07-19-native-multi-agent-design.md
+++ b/docs/superpowers/specs/2026-07-19-native-multi-agent-design.md
@@ -1,0 +1,155 @@
+# Native Multi-Agent Workspaces
+
+## Goal
+
+Allow one CowAgent process to host multiple agents without changing the
+behaviour of existing single-agent installations. Each agent is a complete
+CowAgent workspace, not a lightweight persona overlay.
+
+## Workspace model
+
+An agent profile identifies one workspace root. The existing workspace layout
+is reused unchanged:
+
+```text
+<workspace>/
+├── AGENT.md
+├── USER.md
+├── RULE.md
+├── MEMORY.md
+├── memory/
+├── skills/
+├── knowledge/
+├── output/
+└── scheduler/
+```
+
+The workspace owns the agent's persona, user profile, rules, long-term memory,
+daily memory, search index, conversation history, skills, knowledge, scheduler
+tasks, evolution data, and generated output.
+
+There is no second home directory abstraction. There is also no shared memory
+database with an `agent_id` column. Each workspace keeps using its own
+`memory/long-term/index.db`, matching the current single-agent layout.
+
+## Configuration
+
+The optional configuration is:
+
+```json
+{
+  "default_agent_id": "default",
+  "agents": [
+    {
+      "id": "default",
+      "name": "Default",
+      "workspace": "~/cow",
+      "enabled": true
+    }
+  ],
+  "agent_bindings": []
+}
+```
+
+When `agents` is absent, CowAgent synthesizes one `default` profile from the
+existing `agent_workspace` value. Existing configuration and data therefore
+continue to work without a migration.
+
+Agent IDs are stable, URL-safe identifiers. Workspace paths must be unique.
+Agent deletion is represented as disabling or archiving the profile; workspace
+data is never deleted implicitly.
+
+## Runtime isolation
+
+The runtime key becomes `(agent_id, session_id)`. Initializing an agent resolves
+the profile first, then passes its workspace explicitly through prompt loading,
+memory, tools, skills, scheduler, and persistence.
+
+Process-wide state that currently binds to the first workspace is replaced by
+workspace-keyed registries:
+
+```text
+workspace → MemoryManager
+workspace → ConversationStore
+workspace → SchedulerService / TaskStore
+workspace → memory flush, Deep Dream, and evolution runtime
+```
+
+No agent may obtain a manager, store, or scheduler belonging to another
+workspace, even when both sessions use the same external session identifier.
+
+## Routing
+
+Inbound contexts carry `agent_id`. Resolution follows a deterministic order:
+
+1. exact channel and conversation binding;
+2. channel-level default binding;
+3. configured `default_agent_id`.
+
+Bindings that reference a missing or disabled agent fall back to the default
+agent and emit a warning. Existing channels require no binding and continue to
+use the default agent.
+
+## Web console
+
+The console can list, create, clone, enable, disable, and select agents. It can
+edit the four core files `AGENT.md`, `USER.md`, `RULE.md`, and `MEMORY.md`.
+
+The editor is intentionally not a general filesystem browser. The backend uses
+an allowlist, resolves paths beneath the selected workspace, writes atomically,
+and rejects stale writes using a content revision. Updating a core file evicts
+only that agent's live sessions so its next turn rebuilds the prompt.
+
+New profiles use the existing workspace bootstrap and templates. A new agent
+therefore has the same onboarding and capabilities as the original single
+agent.
+
+## Inter-agent delegation
+
+Agents communicate through a guarded request-response tool:
+
+```text
+agent_delegate(target_agent, message, timeout_seconds)
+```
+
+The target runs in its own workspace and a dedicated relay session. Results
+include source attribution and structured errors. The runtime enforces target
+allowlists, timeouts, cancellation, message limits, maximum delegation depth,
+and cycle detection. Delegated output is returned to the caller and is not sent
+to a user channel automatically.
+
+## Backup and restore
+
+Backups include the registry, bindings, and selected agent workspaces. Restore
+validates manifest versions, profile IDs, workspace destinations, and archive
+paths before writing. Restores remain transactional and preserve the existing
+rollback behaviour.
+
+No import tooling is part of this design.
+
+## Delivery
+
+The work is split into seven ordered changes:
+
+1. agent registry and compatibility configuration;
+2. agent-aware runtime initialization;
+3. workspace-scoped memory, sessions, and scheduler;
+4. channel bindings and routing;
+5. Web console management and core-file editor;
+6. guarded inter-agent delegation;
+7. multi-agent backup, documentation, and final hardening.
+
+Later changes depend on earlier ones. Each change must include its own tests and
+preserve the zero-configuration single-agent path.
+
+## Acceptance criteria
+
+- Existing configurations still use `~/cow` exactly as before.
+- Two agents with the same session ID cannot share runtime state or data.
+- Memory, conversation history, scheduled tasks, skills, and knowledge remain
+  inside the selected workspace.
+- Channel bindings resolve deterministically and fail safely.
+- The console can create an agent and safely edit its four core Markdown files.
+- Delegation cannot recurse forever or bypass disabled-target checks.
+- Backup and restore preserve all configured agents without writing outside
+  approved workspace paths.

--- a/plugins/cow_cli/cow_cli.py
+++ b/plugins/cow_cli/cow_cli.py
@@ -949,7 +949,7 @@ class CowCliPlugin(Plugin):
             from bridge.bridge import Bridge
             bridge = Bridge()
             agent_bridge = bridge.get_agent_bridge()
-            for agent in [agent_bridge.default_agent] + list(agent_bridge.agents.values()):
+            for _agent_id, _session_id, agent in agent_bridge.iter_agent_instances():
                 if agent and hasattr(agent, 'skill_manager') and agent.skill_manager:
                     agent.skill_manager.refresh_skills()
                     break

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+import pytest
+
+from agent.registry import AgentProfile, AgentRegistry, AgentRegistryError
+
+
+def test_legacy_config_synthesizes_default_agent(tmp_path):
+    workspace = tmp_path / "cow"
+    registry = AgentRegistry.from_config({"agent_workspace": str(workspace)})
+
+    profile = registry.get()
+    assert profile.id == "default"
+    assert profile.name == "Default"
+    assert profile.workspace_path == workspace.resolve()
+    assert registry.default_agent_id == "default"
+
+
+def test_configured_agents_keep_separate_workspaces(tmp_path):
+    registry = AgentRegistry.from_config(
+        {
+            "default_agent_id": "writer",
+            "agents": [
+                {"id": "writer", "name": "Writer", "workspace": str(tmp_path / "writer")},
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "workspace": str(tmp_path / "research"),
+                    "model": "gpt-5",
+                    "bot_type": "openai",
+                },
+            ],
+        }
+    )
+
+    assert registry.get().id == "writer"
+    assert registry.get("research").model == "gpt-5"
+    assert registry.get("research").bot_type == "openai"
+    assert [profile.id for profile in registry.list()] == ["research", "writer"]
+
+
+@pytest.mark.parametrize("agent_id", ["", "has space", "/root", "x" * 65])
+def test_invalid_agent_ids_are_rejected(tmp_path, agent_id):
+    with pytest.raises(AgentRegistryError, match="agent id"):
+        AgentRegistry.from_config(
+            {"agents": [{"id": agent_id, "workspace": str(tmp_path / "one")}]}
+        )
+
+
+def test_duplicate_ids_and_workspaces_are_rejected(tmp_path):
+    with pytest.raises(AgentRegistryError, match="duplicate agent id"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "one")},
+                    {"id": "one", "workspace": str(tmp_path / "two")},
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+    with pytest.raises(AgentRegistryError, match="share workspace"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "shared")},
+                    {"id": "two", "workspace": str(tmp_path / "shared")},
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+
+def test_default_agent_must_exist_and_be_enabled(tmp_path):
+    with pytest.raises(AgentRegistryError, match="not configured"):
+        AgentRegistry.from_config(
+            {
+                "agents": [{"id": "one", "workspace": str(tmp_path / "one")}],
+                "default_agent_id": "missing",
+            }
+        )
+
+    with pytest.raises(AgentRegistryError, match="disabled"):
+        AgentRegistry.from_config(
+            {
+                "agents": [
+                    {"id": "one", "workspace": str(tmp_path / "one"), "enabled": False}
+                ],
+                "default_agent_id": "one",
+            }
+        )
+
+
+def test_registry_mutations_preserve_default_invariants(tmp_path):
+    registry = AgentRegistry.from_config({"agent_workspace": str(tmp_path / "default")})
+    second = AgentProfile(
+        id="second",
+        name="Second",
+        workspace=str((tmp_path / "second").resolve()),
+    )
+    registry.upsert(second)
+
+    registry.set_default("second")
+    registry.set_enabled("default", False)
+    assert registry.get().id == "second"
+    assert registry.get_or_default("default").id == "second"
+
+    with pytest.raises(AgentRegistryError, match="default agent cannot be disabled"):
+        registry.set_enabled("second", False)
+    with pytest.raises(AgentRegistryError, match="default agent cannot be removed"):
+        registry.remove("second")
+
+    removed = registry.remove("default")
+    assert removed.id == "default"
+    assert [profile.id for profile in registry.list()] == ["second"]
+
+
+def test_profile_to_dict_omits_empty_overrides(tmp_path):
+    profile = AgentProfile(
+        id="default",
+        name="Default",
+        workspace=str(Path(tmp_path).resolve()),
+    )
+    assert profile.to_dict() == {
+        "id": "default",
+        "name": "Default",
+        "workspace": str(Path(tmp_path).resolve()),
+        "enabled": True,
+    }

--- a/tests/test_multi_agent_runtime.py
+++ b/tests/test_multi_agent_runtime.py
@@ -1,0 +1,132 @@
+import threading
+from types import SimpleNamespace
+
+from agent.registry import AgentRegistry
+from bridge.agent_bridge import AgentBridge
+
+
+class _FakeInitializer:
+    def __init__(self, registry):
+        self.registry = registry
+        self.calls = []
+
+    def initialize_agent(self, session_id=None, agent_id=None):
+        profile = self.registry.get(agent_id)
+        self.calls.append((profile.id, session_id))
+        return SimpleNamespace(
+            agent_id=profile.id,
+            workspace_dir=profile.workspace,
+            messages=[],
+            messages_lock=threading.RLock(),
+        )
+
+
+def _bridge(tmp_path):
+    registry = AgentRegistry.from_config(
+        {
+            "default_agent_id": "primary",
+            "agents": [
+                {
+                    "id": "primary",
+                    "name": "Primary",
+                    "workspace": str(tmp_path / "primary"),
+                },
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "workspace": str(tmp_path / "research"),
+                },
+            ],
+        }
+    )
+    bridge = object.__new__(AgentBridge)
+    bridge.agent_registry = registry
+    bridge._agent_instances = {}
+    bridge._default_agents = {}
+    bridge._agents_lock = threading.RLock()
+    bridge.agents = {}
+    bridge.default_agent = None
+    bridge.initializer = _FakeInitializer(registry)
+    return bridge
+
+
+def test_same_session_id_isolated_by_agent(tmp_path):
+    bridge = _bridge(tmp_path)
+
+    primary = bridge.get_agent(session_id="shared")
+    research = bridge.get_agent(session_id="shared", agent_id="research")
+
+    assert primary is not research
+    assert primary.workspace_dir != research.workspace_dir
+    assert bridge.get_agent(session_id="shared") is primary
+    assert bridge.get_agent(session_id="shared", agent_id="research") is research
+    assert bridge.initializer.calls == [
+        ("primary", "shared"),
+        ("research", "shared"),
+    ]
+
+
+def test_legacy_agents_view_contains_only_default_profile(tmp_path):
+    bridge = _bridge(tmp_path)
+
+    primary = bridge.get_agent(session_id="one")
+    bridge.get_agent(session_id="two", agent_id="research")
+
+    assert bridge.agents == {"one": primary}
+    assert set(bridge._agent_instances) == {
+        ("primary", "one"),
+        ("research", "two"),
+    }
+
+
+def test_default_runtime_is_per_agent_workspace(tmp_path):
+    bridge = _bridge(tmp_path)
+
+    primary = bridge.get_agent()
+    research = bridge.get_agent(agent_id="research")
+
+    assert primary is bridge.default_agent
+    assert primary is not research
+    assert bridge.get_agent() is primary
+    assert bridge.get_agent(agent_id="research") is research
+
+
+def test_clear_session_and_agent_do_not_evict_other_agents(tmp_path):
+    bridge = _bridge(tmp_path)
+    primary = bridge.get_agent(session_id="shared")
+    research = bridge.get_agent(session_id="shared", agent_id="research")
+    bridge.get_agent(session_id="other", agent_id="research")
+
+    bridge.clear_session("shared", agent_id="research")
+    assert bridge.get_cached_agent("shared", agent_id="research") is None
+    assert bridge.get_cached_agent("shared") is primary
+
+    assert bridge.clear_agent("research") == 1
+    assert bridge.get_cached_agent("shared") is primary
+    assert bridge.get_cached_agent("other", agent_id="research") is None
+    assert research not in [item[2] for item in bridge.iter_agent_instances()]
+
+
+def test_iter_agent_instances_reports_agent_and_session(tmp_path):
+    bridge = _bridge(tmp_path)
+    bridge.get_agent()
+    bridge.get_agent(agent_id="research")
+    bridge.get_agent(session_id="chat")
+    bridge.get_agent(session_id="chat", agent_id="research")
+
+    keys = {
+        (agent_id, session_id)
+        for agent_id, session_id, _agent in bridge.iter_agent_instances()
+    }
+    assert keys == {
+        ("primary", None),
+        ("research", None),
+        ("primary", "chat"),
+        ("research", "chat"),
+    }
+
+
+def test_non_default_cancel_keys_are_namespaced(tmp_path):
+    bridge = _bridge(tmp_path)
+    assert bridge._cancel_key("primary", "session", "primary") == "session"
+    assert bridge._cancel_key("research", "session", "primary") == "research::session"

--- a/tests/test_multi_agent_state_isolation.py
+++ b/tests/test_multi_agent_state_isolation.py
@@ -1,0 +1,136 @@
+from pathlib import Path
+
+import pytest
+
+from agent.memory import (
+    MemoryConfig,
+    clear_conversation_store_cache,
+    get_default_memory_config,
+    get_conversation_store,
+    set_global_memory_config,
+)
+from agent.registry import AgentProfile, AgentRegistry, get_agent_registry, set_agent_registry
+from agent.tools.scheduler.integration import (
+    get_scheduler_service,
+    get_task_store,
+    init_scheduler,
+    reset_scheduler_services,
+)
+
+
+@pytest.fixture
+def isolated_registry(tmp_path, monkeypatch):
+    from agent.tools.scheduler.scheduler_service import SchedulerService
+
+    monkeypatch.setattr(
+        SchedulerService, "start", lambda service: setattr(service, "running", True)
+    )
+    monkeypatch.setattr(
+        SchedulerService, "stop", lambda service: setattr(service, "running", False)
+    )
+    previous = get_agent_registry()
+    registry = AgentRegistry(
+        [
+            AgentProfile("primary", "Primary", str(tmp_path / "primary")),
+            AgentProfile("research", "Research", str(tmp_path / "research")),
+        ],
+        default_agent_id="primary",
+    )
+    set_agent_registry(registry)
+    clear_conversation_store_cache()
+    reset_scheduler_services()
+    try:
+        yield registry
+    finally:
+        reset_scheduler_services()
+        clear_conversation_store_cache()
+        set_agent_registry(previous)
+
+
+def _message(text):
+    return {"role": "user", "content": [{"type": "text", "text": text}]}
+
+
+def _task(task_id, name):
+    return {
+        "id": task_id,
+        "name": name,
+        "enabled": False,
+        "schedule": {"type": "cron", "cron": "0 9 * * *"},
+        "action": {"type": "send_message", "content": name},
+    }
+
+
+def test_conversations_with_same_session_id_use_different_databases(
+    isolated_registry,
+):
+    primary = isolated_registry.get("primary")
+    research = isolated_registry.get("research")
+    primary_store = get_conversation_store(primary.workspace)
+    research_store = get_conversation_store(research.workspace)
+
+    primary_store.append_messages("same-session", [_message("primary")])
+    research_store.append_messages("same-session", [_message("research")])
+
+    assert primary_store is not research_store
+    assert primary_store.load_messages("same-session")[0]["content"][0]["text"] == "primary"
+    assert research_store.load_messages("same-session")[0]["content"][0]["text"] == "research"
+    assert Path(primary_store._db_path) == Path(primary.workspace) / "memory/long-term/index.db"
+    assert Path(research_store._db_path) == Path(research.workspace) / "memory/long-term/index.db"
+
+
+def test_memory_config_keeps_each_agent_index_under_its_workspace(
+    isolated_registry,
+):
+    primary = isolated_registry.get("primary")
+    research = isolated_registry.get("research")
+
+    primary_db = MemoryConfig(workspace_root=primary.workspace).get_db_path()
+    research_db = MemoryConfig(workspace_root=research.workspace).get_db_path()
+
+    assert primary_db != research_db
+    assert primary_db == Path(primary.workspace) / "memory/long-term/index.db"
+    assert research_db == Path(research.workspace) / "memory/long-term/index.db"
+
+
+def test_scheduler_stores_allow_same_task_id_per_agent(isolated_registry):
+    class Bridge:
+        agent_registry = isolated_registry
+
+    bridge = Bridge()
+    for profile in isolated_registry.list(include_disabled=False):
+        assert init_scheduler(bridge, profile.workspace, profile.id)
+
+    primary_store = get_task_store(agent_id="primary")
+    research_store = get_task_store(agent_id="research")
+    primary_store.add_task(_task("daily", "Primary daily"))
+    research_store.add_task(_task("daily", "Research daily"))
+
+    assert primary_store is not research_store
+    assert primary_store.get_task("daily")["name"] == "Primary daily"
+    assert research_store.get_task("daily")["name"] == "Research daily"
+    assert Path(primary_store.store_path) == Path(
+        isolated_registry.get("primary").workspace
+    ) / "scheduler/tasks.json"
+    assert Path(research_store.store_path) == Path(
+        isolated_registry.get("research").workspace
+    ) / "scheduler/tasks.json"
+    assert get_scheduler_service(agent_id="primary") is not get_scheduler_service(
+        agent_id="research"
+    )
+
+
+def test_no_argument_conversation_store_preserves_single_agent_default(
+    isolated_registry,
+):
+    previous = get_default_memory_config()
+    default_workspace = isolated_registry.get("primary").workspace
+    try:
+        set_global_memory_config(MemoryConfig(workspace_root=default_workspace))
+        clear_conversation_store_cache()
+        default_store = get_conversation_store()
+        explicit_store = get_conversation_store(default_workspace)
+        assert default_store is explicit_store
+    finally:
+        set_global_memory_config(previous)
+        clear_conversation_store_cache()


### PR DESCRIPTION
## Summary

- give each Agent its own long-term memory index under its workspace
- isolate conversation persistence and session history by Agent workspace
- run one scheduler store and service per Agent, including eager startup
- scope Deep Dream and memory maintenance to the owning workspace

There is no shared database with an `agent_id` discriminator: each Agent keeps its own physical state files.

## Stack

Depends on #2970, which in turn depends on #2969. Please merge in order.

## Test

```bash
python -m pytest -q tests/test_multi_agent_state_isolation.py tests/test_scheduler_run_now.py
```
