### PR TITLE
feat(tools): add search_files tool for workspace content search

### DIFF
--- a/agent/prompt/builder.py
+++ b/agent/prompt/builder.py
@@ -192,6 +192,7 @@ def _build_tooling_section(tools: List[Any], language: str) -> List[str]:
             "write": "create or overwrite a file",
             "edit": "make precise edits to a file",
             "ls": "list directory contents",
+            "search_files": "search file contents by pattern",
             "grep": "search file contents",
             "find": "find files by pattern",
             "bash": "run shell commands",
@@ -212,6 +213,7 @@ def _build_tooling_section(tools: List[Any], language: str) -> List[str]:
             "write": "创建或覆盖文件",
             "edit": "精确编辑文件",
             "ls": "列出目录内容",
+            "search_files": "按模式搜索文件内容",
             "grep": "搜索文件内容",
             "find": "按模式查找文件",
             "bash": "执行shell命令",
@@ -229,7 +231,7 @@ def _build_tooling_section(tools: List[Any], language: str) -> List[str]:
 
     # Preferred display order
     tool_order = [
-        "read", "write", "edit", "ls", "grep", "find",
+        "read", "write", "edit", "ls", "search_files", "grep", "find",
         "bash", "terminal",
         "web_search", "web_fetch", "browser",
         "memory_search", "memory_get",

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -9,6 +9,7 @@ from agent.tools.edit.edit import Edit
 from agent.tools.bash.bash import Bash
 from agent.tools.ls.ls import Ls
 from agent.tools.send.send import Send
+from agent.tools.search_files.search_files import SearchFiles
 
 # Import memory tools
 from agent.tools.memory.memory_search import MemorySearchTool
@@ -130,6 +131,7 @@ __all__ = [
     'Bash',
     'Ls',
     'Send',
+    'SearchFiles',
     'MemorySearchTool',
     'MemoryGetTool',
     'EvolutionUndoTool',

--- a/agent/tools/search_files/__init__.py
+++ b/agent/tools/search_files/__init__.py
@@ -1,0 +1,3 @@
+from .search_files import SearchFiles
+
+__all__ = ['SearchFiles']

--- a/agent/tools/search_files/search_files.py
+++ b/agent/tools/search_files/search_files.py
@@ -1,0 +1,279 @@
+"""
+SearchFiles tool - search file contents across the workspace (grep-like)
+"""
+
+import fnmatch
+import os
+import time
+from typing import Dict, Any, List, Tuple
+
+import regex as re  # not stdlib re: .search() takes a real per-call timeout, stdlib re has none
+
+from agent.tools.base_tool import BaseTool, ToolResult
+from agent.tools.utils.truncate import truncate_line
+from common.utils import expand_path
+
+DEFAULT_MAX_RESULTS = 50
+MAX_RESULTS_CAP = 500
+MAX_FILE_BYTES = 2 * 1024 * 1024
+SEARCH_TIMEOUT_SECONDS = 30
+REGEX_MATCH_TIMEOUT_SECONDS = 1  # caps one regex.search() call; SEARCH_TIMEOUT_SECONDS is the separate overall-walk deadline
+
+# Matches read.py's issue #2913 fix: /proc/<pid|self|thread-self>/environ
+# mirrors any secrets loaded into the process environment from ~/.cow/.env.
+_PROC_ENVIRON_RE = re.compile(r"^/proc/(\d+|self|thread-self)/environ$")
+
+# No `rg` in the Docker image or installers, so this walks pure Python with
+# no .gitignore awareness — a conservative hardcoded denylist, not the same
+# thing as `rg`'s .gitignore-driven skipping.
+_SKIP_DIR_NAMES = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv",
+    ".mypy_cache", ".pytest_cache", "dist", "build", ".next",
+    "target", "vendor", ".tox", "coverage", ".idea",
+}
+
+
+class SearchFiles(BaseTool):
+    """Tool for searching file contents by pattern across a directory tree."""
+
+    name: str = "search_files"
+    description: str = (
+        "Search file contents for a text/regex pattern across a directory tree. "
+        "Returns matching lines with file path and line number. Prefer this over "
+        "`bash` + grep for content search: no shell execution, structured output, "
+        "automatic binary/oversized-file skipping."
+    )
+
+    params: dict = {
+        "type": "object",
+        "properties": {
+            "pattern": {
+                "type": "string",
+                "description": "Text or regex pattern to search for."
+            },
+            "path": {
+                "type": "string",
+                "description": "Directory to search in (default: workspace root). Relative paths are based on workspace directory."
+            },
+            "file_glob": {
+                "type": "string",
+                "description": "Glob to filter which files are searched, e.g. '*.py' (default: all files)."
+            },
+            "max_results": {
+                "type": "integer",
+                "description": f"Maximum number of matches to return (default: {DEFAULT_MAX_RESULTS}, capped at {MAX_RESULTS_CAP})."
+            }
+        },
+        "required": ["pattern"]
+    }
+
+    def __init__(self, config: dict = None):
+        self.config = config or {}
+        self.cwd = self.config.get("cwd", os.getcwd())
+        self.timeout = self.config.get("timeout", SEARCH_TIMEOUT_SECONDS)
+        # Resolved once (assumes ~/.cow is stable for this session), not per-check.
+        self._cow_dir = os.path.realpath(expand_path("~/.cow")).replace(os.sep, "/")
+
+    def execute(self, args: Dict[str, Any]) -> ToolResult:
+        """
+        Execute a content search.
+
+        :param args: pattern (required), path/file_glob/max_results (optional)
+        :return: ToolResult with {matches: [{file, line, match}, ...], match_count, notice?}
+        """
+        pattern = args.get("pattern", "")
+        if not isinstance(pattern, str) or not pattern:
+            return ToolResult.fail("Error: pattern parameter is required")
+
+        path = args.get("path", ".") or "."
+        file_glob = args.get("file_glob", "*") or "*"
+        if not isinstance(file_glob, str):
+            return ToolResult.fail(f"Error: file_glob must be a string, got: {file_glob!r}")
+        max_results = args.get("max_results", DEFAULT_MAX_RESULTS)
+        if isinstance(max_results, float) and not max_results.is_integer():
+            return ToolResult.fail(f"Error: max_results must be an integer, got: {max_results!r}")
+        try:
+            max_results = int(max_results)
+        except (TypeError, ValueError):
+            return ToolResult.fail(f"Error: max_results must be an integer, got: {max_results!r}")
+        if max_results <= 0:
+            return ToolResult.fail("Error: max_results must be a positive integer")
+        max_results = min(max_results, MAX_RESULTS_CAP)
+
+        try:
+            compiled_pattern = re.compile(pattern)
+        except re.error as e:
+            return ToolResult.fail(f"Error: invalid regex pattern: {e}")
+
+        root = self._resolve_path(path)
+        if self._is_credential_path(root):
+            return ToolResult.fail(
+                "Error: Access denied. API keys and credentials must be accessed through the env_config tool only."
+            )
+        if not os.path.exists(root):
+            return ToolResult.fail(
+                f"Error: path not found: {path}\nResolved to: {root}\n"
+                f"Hint: Relative paths are based on workspace ({self.cwd}). For directories outside workspace, use absolute paths."
+            )
+        if not os.path.isdir(root):
+            return ToolResult.fail(f"Error: path is not a directory: {path}")
+
+        matches, timed_out, pattern_timeout, skip_list_pruned = self._search(compiled_pattern, root, file_glob, max_results)
+
+        payload = {"matches": matches, "match_count": len(matches)}
+        notices = []
+        if len(matches) >= max_results:
+            if max_results >= MAX_RESULTS_CAP:
+                # A max_results*2 suggestion here would just echo the same capped number.
+                notices.append(f"{max_results} result limit reached (hard maximum). Narrow `path` or `file_glob` to see more.")
+            else:
+                # Fires even if the true match count exactly equals max_results
+                # (nothing more actually exists) — matches ls.py's identical
+                # entry_limit_reached imprecision, not fixed here either.
+                notices.append(
+                    f"{max_results} result limit reached. "
+                    f"Use max_results={min(max_results * 2, MAX_RESULTS_CAP)} to see more."
+                )
+        if timed_out:
+            notices.append(
+                f"Search stopped after {self.timeout}s — results may be incomplete. "
+                f"Narrow `path` or `file_glob` to search a smaller tree."
+            )
+        if pattern_timeout:
+            notices.append(
+                f"Pattern took longer than {REGEX_MATCH_TIMEOUT_SECONDS}s to match on a line in one "
+                f"or more files — the rest of that file's content was not searched. Results may be "
+                f"incomplete. Simplify `pattern` to avoid catastrophic backtracking."
+            )
+        if skip_list_pruned:
+            notices.append(
+                "Some directories were excluded by a fixed skip-list (e.g. .git, node_modules, "
+                "dist, vendor) — match_count does not reflect their contents."
+            )
+        if notices:
+            # Must live in `result`, not `ToolResult.ext_data` — `_execute_tool`
+            # never forwards `ext_data` to the model.
+            payload["notice"] = " ".join(notices)
+        return ToolResult.success(payload)
+
+    def _resolve_path(self, path: str) -> str:
+        """Resolve path to absolute path (same convention as read/ls/write, no workspace jail)."""
+        path = expand_path(path)
+        if os.path.isabs(path):
+            return path
+        return os.path.abspath(os.path.join(self.cwd, path))
+
+    def _is_credential_path(self, absolute_path: str) -> bool:
+        """Block ~/.cow (like ls.py) and /proc/*/environ (like read.py's
+        #2913 fix), checked per-file right before opening — not just
+        directories pruned during traversal — so a symlink can't bypass this
+        via `open()`. Checks both normalized and realpath forms since
+        resolving symlinks can change which one matches the /proc regex.
+
+        Intentionally broader than read.py's ~/.cow/.env-only check — don't
+        narrow this to match it.
+        """
+        candidates = set()
+        try:
+            candidates.add(os.path.normpath(absolute_path).replace(os.sep, "/"))
+            candidates.add(os.path.realpath(absolute_path).replace(os.sep, "/"))
+        except OSError:
+            candidates.add(absolute_path.replace(os.sep, "/"))
+
+        for candidate in candidates:
+            if _PROC_ENVIRON_RE.match(candidate):
+                return True
+
+        return any(c == self._cow_dir or c.startswith(self._cow_dir + "/") for c in candidates)
+
+    def _search(self, compiled_pattern: re.Pattern, root: str, file_glob: str, max_results: int) -> Tuple[List[Dict[str, Any]], bool, bool, bool]:
+        """Walk the tree under `root`, collecting up to `max_results` matches.
+
+        Returns (matches, timed_out, pattern_timeout, skip_list_pruned).
+        Traversal order is sorted so that truncated results (common once
+        max_results is hit) are deterministic across runs — os.walk's raw
+        order otherwise depends on the filesystem.
+        """
+        matches: List[Dict[str, Any]] = []
+        deadline = time.monotonic() + self.timeout
+        pattern_timeout = False
+        skip_list_pruned = False
+
+        for dirpath, dirnames, filenames in os.walk(root):
+            kept_dirnames = []
+            for d in dirnames:
+                if d in _SKIP_DIR_NAMES:
+                    skip_list_pruned = True
+                    continue
+                if self._is_credential_path(os.path.join(dirpath, d)):
+                    continue
+                kept_dirnames.append(d)
+            dirnames[:] = sorted(kept_dirnames)
+
+            for filename in sorted(filenames):
+                if len(matches) >= max_results:
+                    return matches, False, pattern_timeout, skip_list_pruned
+                if time.monotonic() >= deadline:
+                    return matches, True, pattern_timeout, skip_list_pruned
+                if file_glob and file_glob != "*" and not fnmatch.fnmatch(filename, file_glob):
+                    continue
+
+                file_path = os.path.join(dirpath, filename)
+                if self._is_credential_path(file_path):
+                    continue
+                found, hit_timed_out, hit_pattern_timeout = self._search_single_file(
+                    file_path, compiled_pattern, root, max_results - len(matches), deadline
+                )
+                matches.extend(found)
+                pattern_timeout = pattern_timeout or hit_pattern_timeout
+                if hit_timed_out:
+                    return matches, True, pattern_timeout, skip_list_pruned
+
+        return matches, False, pattern_timeout, skip_list_pruned
+
+    @staticmethod
+    def _search_single_file(file_path: str, compiled_pattern: re.Pattern, root: str, remaining: int, deadline: float) -> Tuple[List[Dict[str, Any]], bool, bool]:
+        """Search one file, returning (matches, timed_out, pattern_timeout) with
+        at most `remaining` matches. Skips oversized/binary/unreadable files.
+
+        `deadline` bounds the whole file, not just each line — without it, a
+        file with many individually-cheap lines could still blow past
+        self.timeout in aggregate, since no single regex.search() call would
+        ever hit REGEX_MATCH_TIMEOUT_SECONDS to trigger the other check.
+        """
+        try:
+            if os.path.getsize(file_path) > MAX_FILE_BYTES:
+                return [], False, False
+        except OSError:
+            return [], False, False
+
+        try:
+            # utf-8-sig (matches read.py) strips a leading BOM; plain utf-8
+            # would leave it as a stray char and break patterns anchored to line 1.
+            with open(file_path, "r", encoding="utf-8-sig") as f:
+                content = f.read()
+        except (UnicodeDecodeError, OSError):
+            return [], False, False
+
+        found: List[Dict[str, Any]] = []
+        for line_no, raw_line in enumerate(content.split("\n"), start=1):
+            # Strip a CRLF-artifact trailing \r (content.split("\n") alone
+            # leaves it) so $-anchors and returned match text behave the same
+            # on Windows-authored files as on \n-only ones.
+            line = raw_line[:-1] if raw_line.endswith("\r") else raw_line
+            if len(found) >= remaining:
+                break
+            if time.monotonic() >= deadline:
+                return found, True, False
+            try:
+                matched = compiled_pattern.search(line, timeout=REGEX_MATCH_TIMEOUT_SECONDS)
+            except TimeoutError:
+                return found, False, True
+            if matched:
+                truncated_content, _ = truncate_line(line)
+                found.append({
+                    "file": os.path.relpath(file_path, root),
+                    "line": line_no,
+                    "match": truncated_content,
+                })
+        return found, False, False

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -371,11 +371,18 @@ class AgentInitializer:
                     # config.json's `tools.<name>` section) instead of replacing
                     # it, otherwise per-tool user configs (e.g. browser.cdp_endpoint)
                     # would be silently dropped.
-                    if tool_name in ['read', 'write', 'edit', 'bash', 'grep', 'find', 'ls', 'web_fetch', 'send', 'browser']:
+                    if tool_name in ['read', 'write', 'edit', 'bash', 'grep', 'find', 'ls', 'web_fetch', 'send', 'browser', 'search_files']:
                         merged_config = dict(getattr(tool, 'config', None) or {})
                         merged_config.update(file_config)
                         tool.config = merged_config
                         tool.cwd = merged_config.get("cwd", getattr(tool, 'cwd', None))
+                        if hasattr(tool, 'timeout'):
+                            # create_tool() builds the instance before tool_configs is
+                            # merged in, so a config-derived .timeout is frozen at its
+                            # __init__-time default; re-derive it here like cwd above,
+                            # for any tool that has one (not name-gated to search_files,
+                            # so a future tool with a .timeout attribute isn't missed).
+                            tool.timeout = merged_config.get("timeout", getattr(tool, 'timeout', None))
                         if 'memory_manager' in merged_config:
                             tool.memory_manager = merged_config['memory_manager']
                     tools.append(tool)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ croniter>=2.0.0
 click>=8.0
 qrcode
 json-repair
+# search_files: search() supports a real per-call timeout, stdlib re does not
+regex>=2019.3.12
 
 # wechatcom & wechatmp
 wechatpy

--- a/tests/test_search_files.py
+++ b/tests/test_search_files.py
@@ -1,0 +1,499 @@
+import os
+import time
+
+import pytest
+
+from common.utils import expand_path
+from agent.tools.search_files.search_files import SearchFiles, REGEX_MATCH_TIMEOUT_SECONDS
+
+
+def _make_tool(tmp_path, **config_overrides):
+    config = {"cwd": str(tmp_path)}
+    config.update(config_overrides)
+    return SearchFiles(config)
+
+
+def _write(tmp_path, relpath, content):
+    path = tmp_path / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _matches(result):
+    return result.result["matches"]
+
+
+def test_appears_with_a_summary_in_the_system_prompt_tooling_section():
+    # Every sibling file tool (read/write/edit/ls) has a one-line summary in
+    # the "Tooling" section of the system prompt the model actually reads;
+    # an entry with no summary ("- search_files" and nothing after it) would
+    # be inconsistent with every other tool and silently degrade tool
+    # selection quality. Only checks the integration point, not the
+    # function's broader behavior (no prior test coverage of builder.py
+    # exists to extend here).
+    from agent.prompt.builder import _build_tooling_section
+
+    fake_tool = type("FakeTool", (), {"name": "search_files"})()
+    for language in ("en", "zh"):
+        lines = _build_tooling_section([fake_tool], language)
+        tooling_line = next(l for l in lines if l.startswith("- search_files"))
+        assert tooling_line != "- search_files", f"missing summary for language={language}"
+
+
+def test_configured_timeout_survives_the_real_tool_manager_wiring(tmp_path, monkeypatch):
+    # Calls the real AgentInitializer._load_tools() — it only touches
+    # self.agent_bridge inside the env_config special case, which search_files
+    # doesn't hit, so bridge=None/agent_bridge=None is enough to exercise the
+    # actual merge logic instead of hand-copying it here.
+    from config import conf
+    from bridge.agent_initializer import AgentInitializer
+
+    monkeypatch.setitem(conf(), "tools", {"search_files": {"timeout": 5}})
+
+    initializer = AgentInitializer(bridge=None, agent_bridge=None)
+    tools = initializer._load_tools(
+        workspace_root=str(tmp_path), memory_manager=None, memory_tools=[], session_id="test-session"
+    )
+    tool = next(t for t in tools if t.name == "search_files")
+    assert tool.timeout == 5
+
+
+# --- input validation -------------------------------------------------
+
+def test_pattern_required_returns_error(tmp_path):
+    tool = _make_tool(tmp_path)
+    result = tool.execute({})
+    assert result.status == "error"
+    assert "pattern" in str(result.result).lower()
+
+
+def test_invalid_regex_returns_error(tmp_path):
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "("})
+    assert result.status == "error"
+    assert "regex" in str(result.result).lower()
+
+
+def test_nonexistent_path_returns_error(tmp_path):
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "x", "path": "does_not_exist"})
+    assert result.status == "error"
+    assert "not found" in str(result.result).lower()
+
+
+def test_path_must_be_a_directory(tmp_path):
+    _write(tmp_path, "file.txt", "hello")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "hello", "path": "file.txt"})
+    assert result.status == "error"
+    assert "directory" in str(result.result).lower()
+
+
+def test_invalid_max_results_returns_error(tmp_path):
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "x", "max_results": 0})
+    assert result.status == "error"
+
+    result = tool.execute({"pattern": "x", "max_results": "not-a-number"})
+    assert result.status == "error"
+
+    # A fractional float must be rejected outright, not silently truncated
+    # by int() (int(3.7) == 3 would otherwise mask a malformed argument).
+    result = tool.execute({"pattern": "x", "max_results": 3.7})
+    assert result.status == "error"
+
+
+def test_integer_valued_float_max_results_is_accepted(tmp_path):
+    # 3.0 is fractional-free (unlike 3.7 above) and must be accepted, not
+    # rejected by the same is_integer() check that catches true fractions.
+    for i in range(5):
+        _write(tmp_path, f"file_{i}.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "max_results": 3.0})
+    assert result.status == "success"
+    assert len(_matches(result)) == 3
+
+
+def test_file_glob_must_be_a_string(tmp_path):
+    # Previously an unhandled TypeError from fnmatch.fnmatch(), swallowed by
+    # base_tool.py's bare `except Exception: logger.error(e)` (no return) into
+    # a bare None the caller then crashes on — instead of a clean ToolResult.fail.
+    _write(tmp_path, "a.txt", "hello\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "hello", "file_glob": 42})
+    assert result.status == "error"
+    assert "file_glob" in str(result.result)
+
+
+# --- security & limits ---------------------------------------------------
+
+def test_max_results_above_hard_cap_is_capped_not_rejected(tmp_path, monkeypatch):
+    import agent.tools.search_files.search_files as sf_module
+    monkeypatch.setattr(sf_module, "MAX_RESULTS_CAP", 3)
+
+    for i in range(5):
+        _write(tmp_path, f"file_{i}.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "max_results": 100000})
+    assert result.status == "success"
+    assert len(_matches(result)) == 3
+    # Must not suggest "use max_results=3" when 3 is already the hard cap —
+    # that would just echo back the same number and read as a no-op suggestion.
+    assert "hard maximum" in result.result["notice"]
+    assert "max_results=3 " not in result.result["notice"]
+    assert "max_results=6" not in result.result["notice"]
+    assert "3 result limit reached" in result.result["notice"]
+
+
+def test_credential_directory_is_blocked(tmp_path):
+    # Matches read.py's test_security_read_env_bypass.py convention: the
+    # direct _is_credential_path check and the execute() end-to-end check
+    # (which must reject before any filesystem walk happens, and doesn't
+    # depend on ~/.cow actually existing) live in the same test.
+    tool = _make_tool(tmp_path)
+    cow_dir = expand_path("~/.cow")
+    assert tool._is_credential_path(cow_dir) is True
+    assert tool._is_credential_path(cow_dir + "/some/nested/file.db") is True
+    assert tool._is_credential_path(str(tmp_path)) is False
+
+    result = tool.execute({"pattern": ".", "path": cow_dir})
+    assert result.status == "error"
+    assert "Access denied" in str(result.result)
+
+
+def test_credential_directory_is_pruned_mid_walk(tmp_path, monkeypatch):
+    # A broad search rooted above ~/.cow (not directly targeting it) must
+    # still prune it during traversal rather than walking into it. Points
+    # expand_path("~/.cow") at a fake dir under tmp_path so this exercises
+    # the real _is_credential_path logic without touching the real home dir.
+    import agent.tools.search_files.search_files as sf_module
+    fake_cow = tmp_path / ".cow"
+    fake_cow.mkdir()
+    (fake_cow / "secret.env").write_text("API_KEY=leaked\n", encoding="utf-8")
+    monkeypatch.setattr(sf_module, "expand_path", lambda p: str(fake_cow) if p == "~/.cow" else p)
+
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "API_KEY"})
+    assert result.status == "success"
+    assert result.result["matches"] == []
+
+
+def test_proc_environ_paths_are_blocked(tmp_path):
+    # Mirrors read.py's own test for issue #2913: pure path-string checks,
+    # no real /proc access needed since _is_credential_path only pattern-matches.
+    tool = _make_tool(tmp_path)
+    assert tool._is_credential_path("/proc/self/environ") is True
+    assert tool._is_credential_path("/proc/thread-self/environ") is True
+    assert tool._is_credential_path(f"/proc/{os.getpid()}/environ") is True
+    assert tool._is_credential_path("/proc/self/status") is False
+    assert tool._is_credential_path("/proc/1/cmdline") is False
+
+
+def test_symlink_to_credential_file_is_skipped_not_opened(tmp_path, monkeypatch):
+    # The bug this guards against: _is_credential_path was only ever called
+    # on directories (traversal pruning) and the root `path` argument — never
+    # on the file actually about to be opened. A symlink inside the searched
+    # tree pointing at a credential file sailed straight through, since
+    # open() follows symlinks. Also verifies the fix is a silent per-file
+    # skip (matches == [] for that file, overall status stays "success"),
+    # not an error that aborts the whole search — a broad search shouldn't
+    # blow up just because it incidentally crosses one bad symlink.
+    import agent.tools.search_files.search_files as sf_module
+    fake_cow = tmp_path / "fake_cow"
+    fake_cow.mkdir()
+    (fake_cow / "secret.env").write_text("API_KEY=super-secret-value\n", encoding="utf-8")
+    monkeypatch.setattr(sf_module, "expand_path", lambda p: str(fake_cow) if p == "~/.cow" else p)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "decoy.txt").symlink_to(fake_cow / "secret.env")
+    (workspace / "real.txt").write_text("API_KEY=this one is fine\n", encoding="utf-8")
+
+    tool = _make_tool(workspace)
+    result = tool.execute({"pattern": "API_KEY"})
+    assert result.status == "success"
+    files = {m["file"] for m in _matches(result)}
+    assert "decoy.txt" not in files
+    assert "real.txt" in files
+
+
+def test_symlinked_directory_pointing_at_credential_dir_is_pruned(tmp_path, monkeypatch):
+    # os.walk's default followlinks=False already refuses to descend into a
+    # symlinked directory regardless of our own check, so this scenario is
+    # doubly protected — but that's exactly why it's worth locking in with a
+    # test: it confirms the dirnames-pruning branch in _search() does what
+    # its comment claims, rather than relying solely on an os.walk default
+    # this code doesn't control.
+    import agent.tools.search_files.search_files as sf_module
+    fake_cow = tmp_path / "fake_cow"
+    fake_cow.mkdir()
+    (fake_cow / "secret.env").write_text("API_KEY=super-secret-value\n", encoding="utf-8")
+    monkeypatch.setattr(sf_module, "expand_path", lambda p: str(fake_cow) if p == "~/.cow" else p)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "decoy_dir").symlink_to(fake_cow, target_is_directory=True)
+
+    tool = _make_tool(workspace)
+    result = tool.execute({"pattern": "API_KEY"})
+    assert result.status == "success"
+    assert result.result["matches"] == []
+
+
+def test_catastrophic_backtracking_pattern_is_preempted(tmp_path):
+    # (a|aa)+$ genuinely defeats the `regex` package's own backtracking
+    # optimizations (unlike simpler nested-quantifier patterns it resolves
+    # instantly) — verified empirically to trip its native per-call timeout.
+    # stdlib re already takes ~2s on this exact input and grows exponentially
+    # from there (a 40-char line takes ~22s), so it has no such bound.
+    _write(tmp_path, "evil.txt", "a" * 35 + "!\n")
+    tool = _make_tool(tmp_path)
+
+    start = time.monotonic()
+    result = tool.execute({"pattern": r"(a|aa)+$"})
+    elapsed = time.monotonic() - start
+
+    assert result.status == "success"
+    assert elapsed < REGEX_MATCH_TIMEOUT_SECONDS + 5
+    assert "took longer than" in result.result["notice"]
+
+
+def test_pattern_leading_trailing_whitespace_is_not_stripped(tmp_path):
+    # Leading/trailing whitespace in `pattern` is meaningful for a regex
+    # ("^ " only matches lines starting with a literal space) and must not
+    # be trimmed the way path-like arguments are elsewhere in this codebase.
+    _write(tmp_path, "a.txt", " leading_space_line\nno_leading_space_line\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "^ "})
+    assert result.status == "success"
+    assert result.result["match_count"] == 1
+    assert "leading_space_line" in _matches(result)[0]["match"]
+
+
+def test_search_stops_at_timeout_and_reports_partial_results(tmp_path):
+    for i in range(3):
+        _write(tmp_path, f"file_{i}.txt", "TARGET\n")
+    # A deadline already in the past forces the very first per-file check
+    # in _search() to trip immediately, before any file is opened.
+    tool = _make_tool(tmp_path, timeout=-1)
+    result = tool.execute({"pattern": "TARGET"})
+    assert result.status == "success"
+    assert result.result["match_count"] == 0
+    assert "stopped after" in result.result["notice"]
+
+
+def test_deadline_is_also_checked_inside_a_single_large_file(tmp_path, monkeypatch):
+    # See _search_single_file's docstring for why this check exists. Fakes
+    # time.monotonic() to advance deterministically instead of sleeping, so
+    # this stays fast and doesn't depend on machine speed.
+    import agent.tools.search_files.search_files as sf_module
+
+    _write(tmp_path, "big.txt", "\n".join(f"line {i}" for i in range(20)) + "\n")
+    tool = _make_tool(tmp_path, timeout=1)
+
+    fake_now = [0.0]
+
+    def fake_monotonic():
+        fake_now[0] += 0.2
+        return fake_now[0]
+
+    monkeypatch.setattr(sf_module.time, "monotonic", fake_monotonic)
+
+    result = tool.execute({"pattern": "nonexistent"})
+    assert result.status == "success"
+    assert "stopped after" in result.result["notice"]
+
+
+def test_traversal_order_is_deterministic(tmp_path):
+    for name in ("zzz.txt", "aaa.txt", "mmm.txt"):
+        _write(tmp_path, name, "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "max_results": 2})
+    assert result.status == "success"
+    files = [m["file"] for m in _matches(result)]
+    assert files == ["aaa.txt", "mmm.txt"]
+
+
+# --- happy path -----------------------------------------------------------
+
+def test_finds_matches_with_file_and_line(tmp_path):
+    _write(tmp_path, "a.py", 'def f():\n    return "TARGET_MATCH here"\n')
+    _write(tmp_path, "sub/b.py", "# another TARGET_MATCH in a subdirectory\nx = 1\n")
+    _write(tmp_path, "notes.txt", "irrelevant, no target word\n")
+
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET_MATCH"})
+    assert result.status == "success"
+    assert result.result["match_count"] == 2
+    assert "notice" not in result.result
+
+    files = {m["file"] for m in _matches(result)}
+    assert files == {"a.py", "sub/b.py"}
+
+    a_match = next(m for m in _matches(result) if m["file"] == "a.py")
+    assert a_match["line"] == 2
+    assert "TARGET_MATCH" in a_match["match"]
+
+
+def test_no_matches_returns_empty_success_not_error(tmp_path):
+    _write(tmp_path, "a.txt", "nothing interesting here\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "NOPE_NOT_PRESENT"})
+    assert result.status == "success"
+    assert result.result["matches"] == []
+    assert result.result["match_count"] == 0
+
+
+def test_file_glob_filters_results(tmp_path):
+    _write(tmp_path, "match.py", "TARGET\n")
+    _write(tmp_path, "match.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "file_glob": "*.py"})
+    assert result.status == "success"
+    assert {m["file"] for m in _matches(result)} == {"match.py"}
+
+
+def test_empty_file_glob_matches_everything_like_the_default(tmp_path):
+    # `file_glob = args.get("file_glob", "*") or "*"` — an empty string is
+    # falsy, so it falls back to "*" the same as omitting the arg entirely.
+    _write(tmp_path, "match.py", "TARGET\n")
+    _write(tmp_path, "match.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "file_glob": ""})
+    assert result.status == "success"
+    assert {m["file"] for m in _matches(result)} == {"match.py", "match.txt"}
+
+
+def test_max_results_caps_output_and_surfaces_notice_to_model(tmp_path):
+    for i in range(10):
+        _write(tmp_path, f"file_{i}.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "max_results": 3})
+    assert result.status == "success"
+    assert len(_matches(result)) == 3
+    assert result.result["match_count"] == 3
+    # The notice must live inside `result.result` — `agent_stream.py`'s
+    # `_execute_tool` only forwards `status`/`result` to the model, so
+    # anything on `ToolResult.ext_data` would silently never reach the LLM.
+    assert result.result["notice"] == "3 result limit reached. Use max_results=6 to see more."
+
+
+def test_binary_files_are_skipped(tmp_path):
+    (tmp_path / "binary.bin").write_bytes(bytes(range(256)))
+    _write(tmp_path, "text.txt", "hello\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "."})
+    assert result.status == "success"
+    files = {m["file"] for m in _matches(result)}
+    assert "binary.bin" not in files
+    assert "text.txt" in files
+
+
+def test_oversized_file_is_skipped_silently_with_no_count_exposed(tmp_path, monkeypatch):
+    # Documents current (accepted) behavior: an oversized file is excluded
+    # like a binary/unreadable one, with no skip-count surfaced anywhere in
+    # the result. Not a bug — just locking in what the description already
+    # promises ("automatic ... oversized-file skipping") so a future change
+    # to add visibility here is a deliberate decision, not a silent regression.
+    import agent.tools.search_files.search_files as sf_module
+    monkeypatch.setattr(sf_module, "MAX_FILE_BYTES", 10)
+
+    _write(tmp_path, "huge.txt", "TARGET " * 20)
+    _write(tmp_path, "small.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET"})
+    assert result.status == "success"
+    assert result.result["match_count"] == 1
+    assert _matches(result)[0]["file"] == "small.txt"
+    assert "skipped" not in str(result.result).lower()
+
+
+def test_utf8_bom_does_not_break_line_start_anchored_patterns(tmp_path):
+    # A UTF-8 BOM (common in Windows-authored files) would decode as a
+    # literal U+FEFF character before line 1 under plain "utf-8", silently
+    # breaking any pattern anchored to the start of the line. Matches
+    # read.py's choice of "utf-8-sig" for the same reason.
+    path = tmp_path / "bom.py"
+    with open(path, "wb") as f:
+        f.write(b"\xef\xbb\xbf")
+        f.write("import os\n".encode("utf-8"))
+
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "^import"})
+    assert result.status == "success"
+    assert result.result["match_count"] == 1
+
+
+def test_crlf_line_endings_do_not_leak_into_matches_or_break_dollar_anchors(tmp_path):
+    # content.split("\n") alone leaves a trailing \r on every line of a
+    # Windows-authored (CRLF) file — breaking $-anchored patterns and leaving
+    # an invisible stray character in the returned match text.
+    with open(tmp_path / "windows.txt", "wb") as f:
+        f.write(b"hello world\r\nfoo\r\n")
+
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "world$"})
+    assert result.status == "success"
+    assert result.result["match_count"] == 1
+    assert _matches(result)[0]["match"] == "hello world"
+
+
+def test_skips_conventional_ignored_directories(tmp_path):
+    _write(tmp_path, ".git/config", "TARGET\n")
+    _write(tmp_path, "node_modules/pkg/index.js", "TARGET\n")
+    _write(tmp_path, "src/app.py", "TARGET\n")
+
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET"})
+    assert result.status == "success"
+    assert {m["file"] for m in _matches(result)} == {"src/app.py"}
+    # match_count alone can't distinguish "genuinely nothing in the skipped
+    # dirs" from "matches were there but pruned" — the notice makes that
+    # ambiguity visible instead of silent.
+    assert "excluded" in result.result["notice"]
+
+
+def test_zero_matches_because_the_only_hit_was_in_a_pruned_directory(tmp_path):
+    # The exact scenario the notice exists for: match_count == 0 here is not
+    # "genuinely nothing" — it's "the only match was inside node_modules and
+    # got pruned" — and only the notice tells those two cases apart.
+    _write(tmp_path, "node_modules/pkg/index.js", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET"})
+    assert result.status == "success"
+    assert result.result["match_count"] == 0
+    assert "excluded" in result.result["notice"]
+
+
+def test_no_skip_list_notice_when_nothing_was_pruned(tmp_path):
+    _write(tmp_path, "src/app.py", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET"})
+    assert result.status == "success"
+    assert "notice" not in result.result
+
+
+# --- path resolution (matches read/ls convention) ----------------------
+
+def test_relative_path_resolves_under_workspace_cwd(tmp_path):
+    _write(tmp_path, "sub/deep.txt", "TARGET\n")
+    tool = _make_tool(tmp_path)
+    result = tool.execute({"pattern": "TARGET", "path": "sub"})
+    assert result.status == "success"
+    assert _matches(result)[0]["file"] == "deep.txt"
+
+
+def test_absolute_path_outside_workspace_is_honored(tmp_path, tmp_path_factory):
+    # Matches the existing read/ls convention: absolute paths are allowed
+    # to point outside the configured workspace `cwd`. Uses tmp_path_factory
+    # (not tmp_path.parent, which is a shared base dir other tests may also
+    # touch) so this stays isolated under parallel test execution.
+    outside = tmp_path_factory.mktemp("search_files_outside")
+    (outside / "f.txt").write_text("TARGET\n", encoding="utf-8")
+
+    tool = _make_tool(tmp_path / "unrelated_workspace")
+    (tmp_path / "unrelated_workspace").mkdir()
+    result = tool.execute({"pattern": "TARGET", "path": str(outside)})
+    assert result.status == "success"
+    assert _matches(result)[0]["file"] == "f.txt"


### PR DESCRIPTION
## What does this PR do?

Adds `search_files` (grep-like content search across the workspace) — closes #2960.

## What changed

- Pure-Python tool (`os.walk` + `regex`), no external binary dependency
- Path resolution matches `read`/`ls`/`write`: relative → workspace `cwd`, absolute/`~` honored as-is, no jail
- Credential protection combines `ls.py`'s `~/.cow` block + `read.py`'s `/proc/*/environ` guard (#2913) — checked per-file right before opening, not just on directories pruned during traversal, so a symlink can't bypass it
- Registered in `agent/tools/__init__.py`, `bridge/agent_initializer.py`'s `cwd`/`timeout` config merge, and `agent/prompt/builder.py`'s tooling summary table
- Pruning by the hardcoded directory skip-list (`.git`, `node_modules`, etc.) now surfaces a notice, so `match_count: 0` can't be silently mistaken for "genuinely nothing" when the only match was actually inside an excluded directory; CRLF line endings no longer leak a trailing `\r` into `$`-anchored patterns or returned match text
- Uses the third-party `regex` module (not stdlib `re`) so a single `search()` call can carry its own timeout — bounds a catastrophically-backtracking user-supplied pattern instead of blocking indefinitely

## Why not `rg`?

The issue proposed preferring `rg` with a Python fallback. CowAgent's Docker image and `run.sh`/`run.ps1` installers never install `rg`, so a dual-engine design would pay ongoing maintenance cost for a fast path most real installs never use — went pure-Python instead.

## Why not subprocess isolation instead of the `regex` dependency?

Went with `regex` (1s timeout) instead of subprocess isolation because the change stays contained to ~10 lines of this file. Subprocess isolation remains the fallback if the dependency isn't acceptable.

## Notes for Reviewer

- **No workspace-bound jail** (issue asked for one) — `read`/`ls`/`write` don't have one either; a jail only on this tool isn't a real boundary since the model can reach the same files via `read`/`bash`.
- **`grep`/`find` naming overlap** — `builder.py`/`agent_initializer.py` already reserve these names (near-identical summary text) with no implementation anywhere. Possible the intended name here was `grep`; kept `search_files` to match the issue title/interface.
- **Known limitation — binary detection is incidental, not sniffed.** A file is only skipped if decoding it as UTF-8 raises `UnicodeDecodeError`; a binary format whose bytes happen to be valid UTF-8 would be read and matched against, returning noisy but not incorrect-looking output (no crash). A real fix (e.g. a null-byte check before decoding) is straightforward but changes how the file is read; not done here since the failure mode is low-likelihood and low-impact — flagging rather than fixing unprompted.
- **`regex` dependency details** — `_search_single_file` passes `timeout=REGEX_MATCH_TIMEOUT_SECONDS` (1s) to every `search()` call. Ships prebuilt wheels for common platforms, no compiler needed. `test_catastrophic_backtracking_pattern_is_preempted` exercises this with a pattern that defeats `regex`'s own backtracking optimizations (verified empirically) rather than one it happens to resolve instantly on its own — see "Why not subprocess isolation?" above for the alternative considered.
- **Two independent timeouts, both now checked per-line** — `REGEX_MATCH_TIMEOUT_SECONDS` bounds one `search()` call; `self.timeout` bounds the whole walk, and as of this round is also checked inside `_search_single_file`'s per-line loop, not just between files (see that method's docstring for why).

## Testing

- `pytest -q tests/test_search_files.py` — 34 passed, 0 skipped
- Full suite: 298 passed, 17 pre-existing failures (confirmed identical on `master`, unrelated to this change), 3 skipped
- Verified through the real dispatch chain (`ToolManager` discovery → `AgentInitializer` cwd-merge → `AgentStreamExecutor._execute_tool`), not just direct `tool.execute()` calls
- Live end-to-end run against `deepseek-chat`: model independently chose to call `search_files` with its own inferred arguments and correctly reported the result
- Perf sanity check: full self-search of this repo (17,663 files) — 0.09s typical, 0.05s worst-case (no matches, full walk)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): closes #2960
