### PR TITLE
fix(desktop): restore Feishu channel via on-demand lark_oapi install (fixes #2987)

### DIFF
--- a/channel/feishu/feishu_channel.py
+++ b/channel/feishu/feishu_channel.py
@@ -11,7 +11,6 @@
 @Date 2023/11/19
 """
 
-import importlib.util
 import json
 import logging
 import os
@@ -50,17 +49,24 @@ logging.getLogger("Lark").setLevel(logging.WARNING)
 
 URL_VERIFICATION = "url_verification"
 
-# Lazy-check for lark_oapi SDK availability without importing it at module level.
-# The full `import lark_oapi` pulls in 10k+ files and takes 4-10s, so we defer
-# the actual import to _startup_websocket() where it is needed.
-LARK_SDK_AVAILABLE = importlib.util.find_spec("lark_oapi") is not None
+# Lazy import of the lark_oapi SDK. The full `import lark_oapi` pulls in 10k+
+# files and takes 4-10s, so we defer the actual import to where it is needed.
+# In desktop mode the SDK is not bundled; the first import triggers an on-demand
+# pip install into a writable per-user dir (see channel/feishu/lark_install.py).
+from channel.feishu import lark_install
+
 lark = None  # will be populated on first use via _ensure_lark_imported()
 
 
 def _ensure_lark_imported():
-    """Import lark_oapi on first use (takes 4-10s due to 10k+ source files)."""
+    """Import lark_oapi on first use (takes 4-10s due to 10k+ source files).
+
+    In desktop mode, if the SDK is missing this triggers an on-demand install
+    (requires network the first time) instead of failing outright.
+    """
     global lark
     if lark is None:
+        lark_install.ensure(allow_install=True)
         import lark_oapi as _lark
         lark = _lark
     return lark
@@ -159,14 +165,6 @@ def _register_via_qr_in_terminal() -> bool:
     Returns True if credentials were obtained AND persisted; False otherwise.
     The caller should fall back to the original "missing credentials" error in that case.
     """
-    if not LARK_SDK_AVAILABLE:
-        logger.error(
-            "[FeiShu] 缺少 feishu_app_id / feishu_app_secret。"
-            "未安装 lark-oapi SDK，无法在终端发起扫码创建。"
-            "请执行 pip install -U 'lark-oapi>=1.5.5' 后重试，或手动在 config.json 中填入凭据。"
-        )
-        return False
-
     try:
         lark_mod = _ensure_lark_imported()
     except Exception as e:
@@ -264,9 +262,12 @@ class FeiShuChanel(ChatChannel):
         conf()["single_chat_prefix"] = [""]
 
         # 验证配置
-        if self.feishu_event_mode == 'websocket' and not LARK_SDK_AVAILABLE:
-            logger.error("[FeiShu] websocket mode requires lark_oapi. Please install: pip install lark-oapi")
-            raise Exception("lark_oapi not installed")
+        if self.feishu_event_mode == 'websocket':
+            try:
+                _ensure_lark_imported()
+            except ImportError as e:
+                logger.error(f"[FeiShu] websocket mode requires lark_oapi: {e}")
+                raise Exception("lark_oapi not installed / could not be installed")
 
     def startup(self):
         self.feishu_app_id = conf().get('feishu_app_id')

--- a/channel/feishu/lark_install.py
+++ b/channel/feishu/lark_install.py
@@ -1,0 +1,117 @@
+"""
+On-demand installer for the ``lark_oapi`` SDK (Feishu channel).
+
+Why this exists
+---------------
+The desktop client (PyInstaller build) intentionally does **not** bundle
+``lark_oapi`` (~116MB + dependencies) so the base download stays small
+(see zhayujie/CowAgent#2987 — "客户端没有飞书通道"). Instead, the first time a
+user enables the Feishu channel in desktop mode, we pip-install ``lark_oapi``
+(and its dependencies) into a writable per-user directory and add it to
+``sys.path``. The module is then imported lazily as before.
+
+For source / non-desktop installs ``lark_oapi`` is expected to be present
+already (it lives in ``requirements.txt``); in that case this module is a
+no-op that simply imports it.
+"""
+import importlib.util
+import logging
+import os
+import subprocess
+import sys
+
+try:
+    from common.log import logger
+except Exception:  # pragma: no cover - common may be unavailable in isolation
+    logger = logging.getLogger("feishu_lark_install")
+
+LARK_PKG = "lark-oapi"
+LARK_MIN = "1.5.5"
+
+# Per-user, writable, persistent location. Mirrors the browser tool's ~/.cow
+# layout so everything CowAgent owns lives under one roof.
+_VENDOR_SUBDIR = os.path.join(".cow", "feishu_vendor")
+
+
+def vendor_dir() -> str:
+    """Return (and create) the directory where lark_oapi is installed on demand."""
+    base = os.environ.get("COW_DATA_DIR") or os.path.expanduser("~")
+    path = os.path.join(base, _VENDOR_SUBDIR)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def is_available() -> bool:
+    """True if lark_oapi can already be imported."""
+    return importlib.util.find_spec("lark_oapi") is not None
+
+
+def ensure(allow_install: bool = True) -> None:
+    """Ensure ``lark_oapi`` can be imported.
+
+    - If already importable, return immediately (source installs, or a previous
+      on-demand install that persisted).
+    - In desktop mode (``COW_DESKTOP=1``) and when ``allow_install`` is True,
+      pip-install ``lark_oapi`` (and its dependencies) on demand into
+      :func:`vendor_dir` and add that directory to ``sys.path``.
+    - Otherwise (non-desktop without the package, or install disabled) raise
+      ``ImportError`` with actionable guidance.
+    """
+    # Fast path: already importable.
+    if is_available():
+        return
+
+    if not allow_install:
+        raise ImportError(
+            "lark_oapi is required for the Feishu channel but is not installed. "
+            "Install it with: pip install -U 'lark-oapi>=%s'" % LARK_MIN
+        )
+
+    # Source / non-desktop installs should already have it via requirements.txt.
+    if os.environ.get("COW_DESKTOP") != "1":
+        raise ImportError(
+            "lark_oapi is required for the Feishu channel but is not installed. "
+            "Install it with: pip install -U 'lark-oapi>=%s'" % LARK_MIN
+        )
+
+    # Desktop mode: install on demand into the user-writable vendor dir.
+    vdir = vendor_dir()
+    if vdir not in sys.path:
+        sys.path.insert(0, vdir)
+    # Re-check: a previous run may have already installed it here.
+    if is_available():
+        return
+
+    logger.warning(
+        "[FeiShu] lark_oapi not found; installing on demand into %s "
+        "(requires network, ~%s+). This only happens once.",
+        vdir, LARK_MIN,
+    )
+    try:
+        subprocess.run(
+            [
+                sys.executable, "-m", "pip", "install",
+                "--target", vdir,
+                "--upgrade",
+                "lark-oapi>=%s" % LARK_MIN,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except Exception as exc:  # noqa: BLE001 - surface a clear, actionable error
+        logger.error("[FeiShu] on-demand lark_oapi install failed: %s", exc)
+        raise ImportError(
+            "Failed to install lark_oapi on demand. A network connection is "
+            "required the first time you enable Feishu. Please connect to the "
+            "internet and retry, or install it manually with: "
+            "pip install -U 'lark-oapi>=%s'" % LARK_MIN
+        ) from exc
+
+    if not is_available():
+        raise ImportError(
+            "lark_oapi could not be imported after on-demand installation. "
+            "Try installing manually: pip install -U 'lark-oapi>=%s'" % LARK_MIN
+        )
+    logger.info("[FeiShu] lark_oapi installed on demand into %s", vdir)

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -3869,13 +3869,9 @@ class ChannelsHandler:
             from common import i18n
             local_config = conf()
             active_channels = self._active_channel_set()
-            # Desktop build ships without lark-oapi, so hide Feishu from the list.
-            desktop_mode = os.environ.get("COW_DESKTOP") == "1"
             channels = []
             is_hant = i18n.get_language() == i18n.ZH_HANT
             for ch_name, ch_def in self.CHANNEL_DEFS.items():
-                if desktop_mode and ch_name == "feishu":
-                    continue
                 fields_out = []
                 for f in ch_def["fields"]:
                     raw_val = local_config.get(f["key"], f.get("default", ""))
@@ -4323,11 +4319,18 @@ class FeishuRegisterHandler:
 
         def _worker():
             try:
+                # Desktop builds don't bundle lark_oapi; install it on demand
+                # the first time the user enables Feishu (requires network).
+                from channel.feishu import lark_install
+                lark_install.ensure(allow_install=True)
                 import lark_oapi as lark
-            except ImportError:
+            except ImportError as e:
                 with cls._lock:
                     cls._state["status"] = "error"
-                    cls._state["error"] = "lark-oapi SDK 未安装，请执行 pip install -U lark-oapi"
+                    cls._state["error"] = (
+                        "lark-oapi SDK 未安装或安装失败，请联网后重试，"
+                        "或手动执行 pip install -U 'lark-oapi>=1.5.5'（%s）" % e
+                    )
                 return
 
             def _on_qr(info):

--- a/desktop/build/cowagent-backend.spec
+++ b/desktop/build/cowagent-backend.spec
@@ -26,9 +26,13 @@ def rp(*parts):
 
 # --- Hidden imports -------------------------------------------------------
 # Channels are imported dynamically by channel_factory via string names, so
-# PyInstaller's static analysis can't see them. List every channel we ship
-# (Feishu is intentionally excluded — lark-oapi is dropped from the desktop
-# build to save ~116MB).
+# PyInstaller's static analysis can't see them. List every channel we ship.
+# Feishu (channel.feishu.feishu_channel) is bundled so the channel code is
+# present; its heavy lark_oapi SDK is deliberately NOT bundled — see the
+# `excludes` note below and channel/feishu/lark_install.py, which installs it
+# on demand the first time the user enables Feishu (fixes
+# zhayujie/CowAgent#2987: "客户端没有飞书通道"). pip/setuptools/wheel are
+# bundled (small) so that on-demand install can run inside the frozen app.
 hiddenimports = [
     # channels (dynamic import in channel/channel_factory.py)
     'channel.web.web_channel',
@@ -37,12 +41,19 @@ hiddenimports = [
     'channel.wechatmp.wechatmp_channel',
     'channel.wechatcom.wechatcomapp_channel',
     'channel.wechat_kf.wechat_kf_channel',
+    'channel.feishu.feishu_channel',
     'channel.dingtalk.dingtalk_channel',
     'channel.wecom_bot.wecom_bot_channel',
     'channel.qq.qq_channel',
     'channel.telegram.telegram_channel',
     'channel.slack.slack_channel',
     'channel.discord.discord_channel',
+    # pip is used by the Feishu on-demand installer (channel/feishu/lark_install.py)
+    # to fetch lark_oapi + its deps inside the frozen desktop app.
+    'pip',
+    'pip._internal',
+    'setuptools',
+    'wheel',
 ]
 
 # Agent tools and model providers are imported lazily in places; collect their
@@ -149,13 +160,19 @@ datas += collect_data_files('pptx')
 datas += collect_data_files('playwright', include_py_files=True)
 
 # --- Excludes -------------------------------------------------------------
-# Keep the bundle lean: drop Feishu's heavy SDK, plugins (disabled in desktop
-# mode), tests/docs, and dev-only packages.
+# Keep the bundle lean: drop tests/docs and dev-only packages.
+#
+# Feishu's lark_oapi (~116MB + deps) is intentionally EXCLUDED here. The desktop
+# client does not bundle it; instead, the first time a user enables the Feishu
+# channel, channel/feishu/lark_install.py pip-installs lark_oapi (and its deps)
+# into a writable per-user dir (~/.cow/feishu_vendor) and adds it to sys.path.
+# This keeps the base download ~116MB smaller while Feishu still works out of
+# the box after a one-time, on-demand download (fixes zhayujie/CowAgent#2987).
+# pip/setuptools/wheel are NOT excluded (see hiddenimports) so that on-demand
+# install can run inside the frozen app.
 excludes = [
-    'lark_oapi',          # Feishu — ~116MB, excluded from desktop build
+    'lark_oapi',          # Feishu SDK — installed on demand, NOT bundled (see above)
     'tests',
-    'pip',
-    'wheel',
     'pytest',
     # NOTE: playwright is now BUNDLED (pure-Python package + Node driver, ~10-15MB)
     # so the browser tool works out of the box on desktop. The heavy Chromium

--- a/desktop/build/requirements-desktop.txt
+++ b/desktop/build/requirements-desktop.txt
@@ -2,9 +2,14 @@
 #
 # Goal: keep the package light. The desktop client only needs the web channel
 # (which Electron talks to) plus the agent core; the remaining IM channels are
-# cheap (~27MB total) so we keep them, but Feishu's `lark-oapi` (~116MB) is
-# dropped — it is by far the heaviest dependency and not needed for a C-end
-# desktop app. Feishu is hidden in desktop mode (see COW_DESKTOP in app.py).
+# cheap (~27MB total) so we keep them.
+#
+# Feishu's `lark-oapi` (~116MB + deps) is NOT listed here on purpose: the desktop
+# client installs it on demand the first time the user enables the Feishu channel
+# (channel/feishu/lark_install.py), keeping the base download ~116MB smaller.
+# pip/setuptools/wheel are required by that on-demand installer and must be
+# present in the build/run environment (they ship inside the frozen app too — see
+# the spec's hiddenimports), so they stay available.
 
 # ---- core ----
 numpy>=1.21
@@ -48,7 +53,8 @@ python-pptx
 # Chrome/Edge, or downloads Chromium on demand into ~/.cow at first use.
 playwright==1.52.0
 
-# ---- IM channels (kept; lightweight). Feishu/lark-oapi intentionally excluded. ----
+# ---- IM channels (kept; lightweight). Feishu/lark-oapi is installed on demand
+#      by the desktop client when the user enables the channel (see header note). ----
 wechatpy
 pycryptodome
 dingtalk_stream
@@ -56,3 +62,7 @@ websocket-client>=1.4.0
 python-telegram-bot
 slack_bolt
 discord.py
+# pip/setuptools/wheel back the Feishu on-demand installer; ensure they are present.
+pip
+setuptools
+wheel

--- a/tests/test_feishu_lark_install.py
+++ b/tests/test_feishu_lark_install.py
@@ -1,0 +1,92 @@
+"""Tests for channel.feishu.lark_install (on-demand lark_oapi installer)."""
+import importlib.util
+import sys
+from unittest import mock
+
+import pytest
+
+from channel.feishu import lark_install
+
+
+@pytest.fixture
+def clean_vendor(monkeypatch, tmp_path):
+    """Point the vendor dir at a temp location and drop any lark_oapi from path."""
+    monkeypatch.setenv("COW_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("COW_DESKTOP", raising=False)
+    # Ensure lark_oapi is not importable in this test process.
+    monkeypatch.setattr(lark_install, "is_available", lambda: False)
+    # Avoid real subprocess / real sys.path pollution.
+    monkeypatch.setattr(subprocess_run := lark_install.subprocess, "run", mock.MagicMock())
+    yield tmp_path
+
+
+def test_is_available_true_when_spec_found(monkeypatch):
+    monkeypatch.setattr(
+        importlib.util, "find_spec", lambda name: object() if name == "lark_oapi" else None
+    )
+    assert lark_install.is_available() is True
+    assert lark_install.is_available() is False or True  # second call path-independent
+
+
+def test_ensure_returns_when_already_available(monkeypatch):
+    monkeypatch.setattr(lark_install, "is_available", lambda: True)
+    # Should not attempt any install.
+    with mock.patch.object(lark_install.subprocess, "run") as run:
+        lark_install.ensure(allow_install=True)
+    run.assert_not_called()
+
+
+def test_ensure_non_desktop_raises(monkeypatch):
+    monkeypatch.setattr(lark_install, "is_available", lambda: False)
+    monkeypatch.delenv("COW_DESKTOP", raising=False)
+    with pytest.raises(ImportError):
+        lark_install.ensure(allow_install=True)
+
+
+def test_ensure_allow_install_false_raises(monkeypatch):
+    monkeypatch.setattr(lark_install, "is_available", lambda: False)
+    monkeypatch.setenv("COW_DESKTOP", "1")
+    with pytest.raises(ImportError):
+        lark_install.ensure(allow_install=False)
+
+
+def test_ensure_desktop_installs_on_demand(monkeypatch, tmp_path):
+    # Simulate: not available before, available after install.
+    state = {"installed": False}
+
+    def fake_available():
+        return state["installed"]
+
+    monkeypatch.setattr(lark_install, "is_available", fake_available)
+    monkeypatch.setenv("COW_DESKTOP", "1")
+    monkeypatch.setattr(lark_install, "vendor_dir", lambda: str(tmp_path))
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        state["installed"] = True  # pretend pip succeeded
+        return mock.MagicMock()
+
+    monkeypatch.setattr(lark_install.subprocess, "run", fake_run)
+
+    # Should not raise; install command must target the vendor dir.
+    lark_install.ensure(allow_install=True)
+    assert calls, "expected a pip install to have been attempted"
+    cmd = calls[0]
+    assert str(tmp_path) in cmd  # --target points at the vendor dir
+    assert "install" in cmd
+    assert any("lark-oapi" in str(part) for part in cmd)  # lark-oapi>=1.5.5 spec
+
+
+def test_ensure_desktop_install_failure_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(lark_install, "is_available", lambda: False)
+    monkeypatch.setenv("COW_DESKTOP", "1")
+    monkeypatch.setattr(lark_install, "vendor_dir", lambda: str(tmp_path))
+
+    def fake_run(cmd, **kwargs):
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr(lark_install.subprocess, "run", fake_run)
+
+    with pytest.raises(ImportError):
+        lark_install.ensure(allow_install=True)


### PR DESCRIPTION
## Summary

Fixes #2987 — the desktop client (v2.1.x) has no Feishu channel because `lark-oapi` (~116MB + deps) was dropped from the PyInstaller build to shrink the download. Re-bundling it just trades size for the feature, so instead **Feishu is installed on demand** the first time a user enables it. The base download stays ~116MB smaller and Feishu still works out of the box.

### What changed
- **New `channel/feishu/lark_install.py`**: in desktop mode (`COW_DESKTOP=1`), when the Feishu channel is first used, `pip install lark-oapi` (and its deps `requests_toolbelt`/`websockets`/`httpx`/…) into a writable per-user dir (`~/.cow/feishu_vendor`), add it to `sys.path`, then import lazily. Source/non-desktop installs import it directly (no-op).
- **`channel/feishu/feishu_channel.py`**: every `lark_oapi` import now goes through `_ensure_lark_imported()`, which triggers the on-demand install instead of failing. The `__init__` websocket guard and the CLI QR-register guard do the same.
- **`channel/web/web_channel.py`**: stop hiding Feishu from the channel list in desktop mode (so the Electron UI + web console show it), and make `FeishuRegisterHandler` (QR one-click app creation) also install on demand.
- **`desktop/build/cowagent-backend.spec`**: keep `lark_oapi` excluded (base stays lean), add `channel.feishu.feishu_channel` to `hiddenimports`, and bundle `pip`/`setuptools`/`wheel` (small) so the on-demand install can run inside the frozen app.
- **`desktop/build/requirements-desktop.txt`**: drop `lark-oapi` (installed on demand); keep `pip`/`setuptools`/`wheel` available.

The frontend (`ChannelsPage.tsx`) is data-driven and already supports Feishu (icon, QR register, field form), so no frontend change is needed.

## Why this is better than re-bundling
- Base download: **no +116MB** (only a small `pip`/`setuptools`/`wheel` (~15MB) is added so on-demand install works).
- Feishu still works after a one-time, on-demand download when first enabled.
- If offline at enable time, the user gets a clear, actionable error (connect to network or `pip install -U 'lark-oapi>=1.5.5'`).

## Test plan
- [ ] `tests/test_feishu_lark_install.py` passes (6 cases: already-available, non-desktop raises, allow_install=False raises, desktop installs on demand, install failure raises).
- [ ] With `COW_DESKTOP=1`, `GET /api/channels` returns `feishu`.
- [ ] Enabling Feishu in desktop triggers `pip install lark-oapi` into `~/.cow/feishu_vendor` (needs network the first time); afterwards it persists.
- [ ] WebSocket connect + QR register both work after on-demand install.
- [ ] Source install (lark_oapi already present) is unaffected.

Note: the on-demand install path targets the frozen desktop app and should be validated in a real desktop build; the unit tests cover the installer logic with mocks.