### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ curl -O https://cdn.link-ai.tech/code/cow/docker-compose.yml
 docker compose up -d
 ```
 
+**Sealos Cloud:**
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/chatgpt-on-wechat)
+
+The template provisions a password-protected HTTPS Web console and a persistent workspace. Set `WEB_PASSWORD` during deployment.
+
 Once started, open `http://localhost:9899` to access the **Web console** — your one-stop hub to chat with the Agent, configure models, connect channels, and install skills.
 
 > Deploying on a server? Set `web_host` to `0.0.0.0` in `config.json` to make the console reachable from outside, and set `web_password` to protect it. Don't forget to open port `9899` in your firewall or security group.


### PR DESCRIPTION
> **Dependency:** The live-validated template update is tracked in https://github.com/labring-actions/templates/pull/731. This pull request remains a draft until that change is merged and the CowAgent App Store URL returns HTTP 200.

## What does this PR do?

This PR adds a Sealos deployment option to the Quick Start section.

The community-maintained template provisions CowAgent with:

- a required `WEB_PASSWORD` for the public Web console
- a persistent workspace at `/home/agent/cow`
- a TLS-enabled application endpoint

The deployment path stays separate from CowAgent's application code and existing
installation methods.

## Validation

- Sealos template: https://sealos.io/products/app-store/chatgpt-on-wechat
- Template source: https://github.com/labring-actions/templates/tree/kb-0.9/template/chatgpt-on-wechat
- App version: CowAgent 2.1.3
- Tested deployment: 2026-07-24
- Verified: password login, Models and Skills navigation, and restart persistence
- Persistence: `/home/agent/cow`
- Required input documented: `WEB_PASSWORD`

## Maintenance

I can help maintain the Sealos deployment path and follow up when the CowAgent
runtime requirements or template documentation change.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the Contributing Guide
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue: N/A