### PR TITLE
fix(memory): sync agent_workspace to the global memory config

### DIFF
--- a/agent/memory/config.py
+++ b/agent/memory/config.py
@@ -104,8 +104,16 @@ def get_default_memory_config() -> MemoryConfig:
 def set_global_memory_config(config: MemoryConfig):
     """
     Set the global memory configuration.
-    This should be called before creating any MemoryManager instances.
-    
+
+    get_default_memory_config() lazily falls back to a MemoryConfig() with
+    the hardcoded ~/cow default the first time anything calls it. Call this
+    before either of the following happens, otherwise:
+    - MemoryManager() instances created without an explicit config= pick
+      up the wrong workspace.
+    - ConversationStore, the evolution executor, and the evolution-undo
+      tool always read via get_default_memory_config() (they take no
+      config= override), so they depend on this unconditionally.
+
     Args:
         config: MemoryConfig instance to use globally
         

--- a/app.py
+++ b/app.py
@@ -315,12 +315,61 @@ def _warmup_scheduler():
         logger.warning(f"[App] Scheduler warmup failed: {e}")
 
 
+def _init_global_memory_config():
+    """
+    Fulfills set_global_memory_config's contract (see its docstring) at
+    process startup, before GET /api/sessions - fired by the web UI on
+    page load, without going through AgentInitializer - can lock the
+    singleton onto ~/cow ahead of the first chat message.
+    """
+    try:
+        from agent.memory import MemoryConfig, set_global_memory_config
+        from common.utils import expand_path
+        workspace_root = expand_path(conf().get("agent_workspace", "~/cow"))
+        set_global_memory_config(MemoryConfig(workspace_root=workspace_root))
+        _warn_if_legacy_workspace_data_exists(workspace_root)
+    except Exception as e:
+        logger.warning(f"[App] Failed to init global memory config: {e}")
+
+
+def _warn_if_legacy_workspace_data_exists(workspace_root: str):
+    """
+    Warn if the hardcoded ~/cow default holds data that agent_workspace
+    doesn't - e.g. after changing agent_workspace without moving the old
+    directory's contents over. The new workspace would otherwise look
+    empty even though old data still exists, with no indication why.
+    """
+    try:
+        from common.utils import expand_path
+        legacy_root = expand_path("~/cow")
+        # samefile checks filesystem identity, so case-insensitive filesystems
+        # (default on Windows and macOS) are handled correctly - normcase
+        # alone isn't enough, since it only folds case on Windows. Falls back
+        # when either path doesn't exist yet (samefile requires both to).
+        try:
+            same = os.path.samefile(legacy_root, workspace_root)
+        except OSError:
+            same = os.path.normcase(os.path.realpath(legacy_root)) == os.path.normcase(os.path.realpath(workspace_root))
+        if same:
+            return
+        # Non-empty check, not a specific file - covers session/skills/memory alike.
+        if os.path.isdir(legacy_root) and os.listdir(legacy_root):
+            logger.warning(
+                f"[App] Found existing data at the default workspace ({legacy_root}) "
+                f"that doesn't match your configured agent_workspace ({workspace_root}). "
+                f"It is not migrated automatically - if it has session history, memory, "
+                f"or skills you want to keep, move it into {workspace_root} manually."
+            )
+    except Exception as e:
+        logger.warning(f"[App] Legacy workspace check failed: {e}")
+
+
 def _sync_builtin_skills():
     """Sync builtin skills from project skills/ to workspace skills/ on startup."""
     import shutil
     try:
-        workspace = conf().get("agent_workspace", "~/cow")
-        workspace = os.path.expanduser(workspace)
+        from common.utils import expand_path
+        workspace = expand_path(conf().get("agent_workspace", "~/cow"))
         project_root = os.path.dirname(os.path.abspath(__file__))
         builtin_dir = os.path.join(project_root, "skills")
         custom_dir = os.path.join(workspace, "skills")
@@ -353,6 +402,9 @@ def run():
     try:
         # load config
         load_config()
+        # Prime the global memory config before GET /api/sessions (fired by
+        # the web UI on page load) can lazily default it to ~/cow.
+        _init_global_memory_config()
         # ctrl + c
         sigterm_handler_wrap(signal.SIGINT)
         # kill signal

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -272,11 +272,16 @@ class AgentInitializer:
         memory_tools = []
         
         try:
-            from agent.memory import MemoryManager, MemoryConfig
+            from agent.memory import MemoryManager, MemoryConfig, set_global_memory_config
             from agent.tools import MemorySearchTool, MemoryGetTool
             from config import conf
 
             memory_config = MemoryConfig(workspace_root=workspace_root)
+            # MemoryManager below takes memory_config directly, so this call
+            # isn't for its own sake - it's for ConversationStore/evolution,
+            # which read the singleton unconditionally (see
+            # set_global_memory_config's docstring).
+            set_global_memory_config(memory_config)
 
             embedding_provider = self._init_embedding_provider(
                 memory_config, session_id=session_id

--- a/tests/test_memory_global_config.py
+++ b/tests/test_memory_global_config.py
@@ -1,0 +1,233 @@
+# encoding:utf-8
+"""
+Regression tests for `agent_workspace` not being honored everywhere - see
+`set_global_memory_config()` (agent/memory/config.py) and its two call
+sites, `AgentInitializer._setup_memory_system` and
+`app._init_global_memory_config`, for the underlying contract each test
+here pins.
+"""
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+import unittest.mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from config import conf, load_config
+
+
+class TestMemoryGlobalConfigSync(unittest.TestCase):
+    def setUp(self):
+        load_config()
+        self.tmp = tempfile.mkdtemp()
+        self._real_home = os.environ.get("HOME")
+        os.environ["HOME"] = self.tmp
+        self.workspace = os.path.join(self.tmp, "custom_workspace")
+        os.makedirs(self.workspace)
+
+        self._orig_agent_workspace = conf().get("agent_workspace")
+        conf()["agent_workspace"] = self.workspace
+
+        # Reset the process-wide singletons so earlier tests/imports in the
+        # same run can't leave a stale ~/cow-pointed config behind.
+        import agent.memory.config as memory_config_module
+        import agent.memory.conversation_store as conversation_store_module
+        self._orig_global_memory_config = memory_config_module._global_memory_config
+        self._orig_store_instance = conversation_store_module._store_instance
+        memory_config_module._global_memory_config = None
+        conversation_store_module._store_instance = None
+
+    def tearDown(self):
+        import agent.memory.config as memory_config_module
+        import agent.memory.conversation_store as conversation_store_module
+        memory_config_module._global_memory_config = self._orig_global_memory_config
+        conversation_store_module._store_instance = self._orig_store_instance
+
+        if self._orig_agent_workspace is None:
+            conf().pop("agent_workspace", None)
+        else:
+            conf()["agent_workspace"] = self._orig_agent_workspace
+
+        if self._real_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._real_home
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_setup_memory_system_syncs_global_config(self):
+        from bridge.agent_initializer import AgentInitializer
+        from agent.memory.config import get_default_memory_config
+
+        initializer = AgentInitializer(bridge=None, agent_bridge=None)
+        initializer._setup_memory_system(self.workspace, session_id=None)
+
+        global_workspace = str(get_default_memory_config().get_workspace())
+        self.assertEqual(
+            global_workspace,
+            self.workspace,
+            "get_default_memory_config() should reflect the configured "
+            "agent_workspace after agent init, not the hardcoded ~/cow default",
+        )
+
+    def test_conversation_store_shares_the_configured_workspace(self):
+        from bridge.agent_initializer import AgentInitializer
+        from agent.memory import get_conversation_store
+
+        initializer = AgentInitializer(bridge=None, agent_bridge=None)
+        initializer._setup_memory_system(self.workspace, session_id=None)
+
+        store = get_conversation_store()
+        self.assertTrue(
+            str(store._db_path).startswith(self.workspace),
+            f"ConversationStore db_path {store._db_path} should live under "
+            f"the configured workspace {self.workspace}, not ~/cow",
+        )
+
+    def test_app_startup_closes_the_early_access_race(self):
+        """
+        Simulates the real failure mode: GET /api/sessions calls
+        get_conversation_store() directly on page load, before any chat
+        message has ever run AgentInitializer.
+        """
+        import app
+        from agent.memory import get_conversation_store
+
+        app._init_global_memory_config()
+
+        # No AgentInitializer / _setup_memory_system call happens here -
+        # this is the early race, exercised directly.
+        store = get_conversation_store()
+        self.assertTrue(
+            str(store._db_path).startswith(self.workspace),
+            f"ConversationStore db_path {store._db_path} should live under "
+            f"the configured workspace {self.workspace} even when accessed "
+            f"before the first agent init, not ~/cow",
+        )
+
+    def test_cold_conversation_store_defaults_to_cow_without_priming(self):
+        """
+        The fix's correctness rests entirely on _init_global_memory_config()
+        running before anything can call get_conversation_store() /
+        get_default_memory_config() for the first time - an ordering
+        contract enforced only by statement order in app.run(), not by any
+        type system or guard. This pins what actually happens if that
+        contract is ever violated (e.g. a future refactor reorders run()),
+        so a regression here fails loudly instead of quietly reappearing.
+        """
+        from agent.memory import get_conversation_store
+        from common.utils import expand_path
+
+        # No _init_global_memory_config() call - this is the unguarded path.
+        store = get_conversation_store()
+        legacy_root = expand_path("~/cow")
+        self.assertTrue(
+            str(store._db_path).startswith(legacy_root),
+            f"without priming, get_conversation_store() is expected to fall "
+            f"back to the hardcoded {legacy_root} default even though "
+            f"agent_workspace is set to {self.workspace} - this documents "
+            f"the failure mode the ordering in app.run() must prevent",
+        )
+
+
+class TestLegacyWorkspaceWarning(unittest.TestCase):
+    """
+    `_warn_if_legacy_workspace_data_exists` is a read-only safety net: it
+    never moves or touches data, only logs when the hardcoded `~/cow`
+    default holds data that the configured workspace doesn't. HOME is
+    redirected to an isolated temp dir so this never touches the real
+    `~/cow` on the machine running the test.
+    """
+
+    def setUp(self):
+        load_config()
+        self.tmp = tempfile.mkdtemp()
+        self._real_home = os.environ.get("HOME")
+        os.environ["HOME"] = self.tmp
+
+        self.legacy_root = os.path.join(self.tmp, "cow")
+        self.new_workspace = os.path.join(self.tmp, "custom_workspace")
+        os.makedirs(self.new_workspace)
+
+    def tearDown(self):
+        if self._real_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._real_home
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_legacy_db(self):
+        legacy_db_dir = os.path.join(self.legacy_root, "memory", "long-term")
+        os.makedirs(legacy_db_dir, exist_ok=True)
+        with open(os.path.join(legacy_db_dir, "index.db"), "wb") as f:
+            f.write(b"")
+
+    def test_warns_when_legacy_data_exists_at_a_different_path(self):
+        import app
+
+        self._write_legacy_db()
+        with self.assertLogs("log", level="WARNING") as cm:
+            app._warn_if_legacy_workspace_data_exists(self.new_workspace)
+
+        self.assertTrue(
+            any(self.legacy_root in msg and self.new_workspace in msg for msg in cm.output),
+            f"Expected a warning naming both {self.legacy_root} and "
+            f"{self.new_workspace}, got: {cm.output}",
+        )
+
+    def test_warns_on_leftover_data_thats_not_the_memory_db(self):
+        """
+        The warning message promises to catch "session history, memory, or
+        skills" - not just the long-term memory DB. A skills-only leftover
+        (no memory/long-term/index.db at all) must still trigger it.
+        """
+        import app
+
+        os.makedirs(os.path.join(self.legacy_root, "skills", "some-skill"))
+        with self.assertLogs("log", level="WARNING") as cm:
+            app._warn_if_legacy_workspace_data_exists(self.new_workspace)
+
+        self.assertTrue(
+            any(self.legacy_root in msg for msg in cm.output),
+            f"Expected a warning naming {self.legacy_root}, got: {cm.output}",
+        )
+
+    def test_no_warning_when_workspace_is_already_the_legacy_default(self):
+        import app
+        import logging
+
+        self._write_legacy_db()
+        logger = logging.getLogger("log")
+        with unittest.mock.patch.object(logger, "warning") as mock_warning:
+            app._warn_if_legacy_workspace_data_exists(self.legacy_root)
+        mock_warning.assert_not_called()
+
+    def test_no_warning_when_paths_differ_only_by_case(self):
+        """
+        ~/cow and ~/COW are the same directory on a case-insensitive
+        filesystem (default on Windows and macOS). Uses real files, not
+        mocked os.path calls - a mocked version previously forced
+        Windows-like case-folding on every OS, masking a real bug where
+        this comparison failed on macOS/Linux. Skips on a case-sensitive
+        filesystem.
+        """
+        import app
+        import logging
+
+        self._write_legacy_db()
+        differently_cased_workspace = self.legacy_root.upper()
+        is_case_insensitive = os.path.isdir(differently_cased_workspace) and os.path.samefile(
+            self.legacy_root, differently_cased_workspace
+        )
+        if not is_case_insensitive:
+            self.skipTest("filesystem is case-sensitive; premise doesn't apply")
+
+        logger = logging.getLogger("log")
+        with unittest.mock.patch.object(logger, "warning") as mock_warning:
+            app._warn_if_legacy_workspace_data_exists(differently_cased_workspace)
+        mock_warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

### Problem

`agent_workspace` is a documented config option (see `agent_workspace` in the [manual-install guide](https://docs.cowagent.ai/guide/manual-install)) meant to be the one place all agent-generated data lives — skills, memory, knowledge, session history, evolution artifacts.

In practice, only part of that was true. `ConversationStore` (session history), the evolution executor, and the evolution-undo tool don't receive the resolved workspace directly — they call `get_default_memory_config()`, a process-wide singleton that lazily defaults to the hardcoded `~/cow` the first time *anything* calls it. `set_global_memory_config()` exists specifically to keep that singleton in sync with `agent_workspace`, but was only ever called from test helpers, never from production code.

Net effect for anyone with a custom `agent_workspace`:
- Session/chat history silently lands in `~/cow` instead of the configured workspace, split away from memory/knowledge (which *did* honor the setting correctly).
- Self-evolution resolves `MEMORY.md` / skill paths to back up and edit via the same broken singleton, so it can target the wrong (likely nonexistent) files instead of the ones the user actually sees.
- `cow backup` packages `agent_workspace` wholesale, so a backup silently excludes session history for anyone on a custom workspace.

This is the default failure mode for the intended use case, not an edge case — and fixing it only where `agent_workspace` is first resolved isn't enough: `GET /api/sessions` (fired by the web console on page load, before any chat) reaches the singleton directly, without going through `AgentInitializer`. Whichever path gets there first wins; if it's this one, `~/cow` is locked in before the "correct" call ever runs.

### How to Reproduce

#### Case A — `~/cow` doesn't exist yet (never ran on the default before)

1. Set `agent_workspace` in `config.json` to anything other than the default `~/cow`, then start the app (`python3 app.py` or `cow start`).
2. Open the web console (`http://localhost:9899`) — page load alone fires `GET /api/sessions`, before you send any message.
3. Check `~/cow` on disk.

- Expected: doesn't exist — everything lives under the configured `agent_workspace`.
- Actual (on `master`, before this PR): `~/cow/memory/long-term/index.db` gets created, by `get_conversation_store()` falling back to the hardcoded default before `agent_workspace` was ever synced to the singleton.

#### Case B — `~/cow` already has data (you used the default before switching to a custom `agent_workspace`)

Existence alone proves nothing here — it's supposed to still be there. There's also no migration tooling (see Notes for Reviewer), so this is the more common real-world path than Case A.

1. Note the current mtime/size of `~/cow/memory/long-term/index.db`.
2. Switch `agent_workspace` to a custom path, restart, open the web console, and send a chat message.
3. Check that file's mtime/size again.

- Expected: unchanged — the new message's session data should land under the newly configured workspace instead.
- Actual (on `master`, before this PR): it grew — new session data is still landing in `~/cow`, with nothing surfacing that it happened.

### Solution

Two call sites now keep the global singleton in sync, closing both the steady-state gap and the startup race:

1. **`AgentInitializer._setup_memory_system`** — calls `set_global_memory_config()` right after building `MemoryConfig`, fulfilling the contract `set_global_memory_config`'s docstring describes — expanded in this PR to name `ConversationStore`/evolution as the real dependents, not just `MemoryManager`.
2. **`app._init_global_memory_config()`** — primes the singleton once, immediately after `load_config()`, before `GET /api/sessions` (or anything else) can reach it first. This is the change that actually closes the race described above.

Also added `app._warn_if_legacy_workspace_data_exists()`: a read-only startup check that warns if `~/cow` still holds data the configured workspace doesn't — covers both upgrading from before this fix, and manually relocating `agent_workspace` without moving old files (there's no tooling for that today, so it's an easy mistake to make). It checks for *any* leftover content, not just the memory DB, so it won't drift out of sync with new data types added under the workspace root later.

Deliberately **not** included: automatic migration of the old data. Merging SQLite tables unreviewed felt like too much risk for a bug-fix PR — the `_warn_if_legacy_workspace_data_exists()` check above just points you at where the old data is; it doesn't move anything for you.

### Changes

| File | Change |
|---|---|
| `agent/memory/config.py` | Expanded `set_global_memory_config`'s docstring to actually name its real callers (ConversationStore, evolution executor/undo tool) instead of only the MemoryManager case, since the other two call sites below point readers here |
| `bridge/agent_initializer.py` | Call `set_global_memory_config()` in `_setup_memory_system` after constructing `MemoryConfig` |
| `app.py` | Add `_init_global_memory_config()` (wired into `run()` right after `load_config()`) and `_warn_if_legacy_workspace_data_exists()`, which compares `~/cow` against the configured workspace with `os.path.samefile` (falling back to string comparison if either doesn't exist yet) rather than `normcase`/`realpath` alone — the latter only folds case on Windows, so it misreported same-directory-different-case paths as distinct on macOS/Linux |
| `app.py` (opportunistic, unrelated to the singleton bug) | Switch `_sync_builtin_skills` from `os.path.expanduser` to `expand_path`. It was the one function left in this file without `expand_path`'s Windows fallback, so it could resolve `agent_workspace` to a different path than everything else here |
| `tests/test_memory_global_config.py` (new) | 8 tests covering both sync points, the "cold" (unprimed) failure mode the fix depends on not reaching, and the legacy-data warning (including non-DB leftovers and a Windows/macOS case-insensitivity edge case) |

### Testing

**Manual**: reproduced the original bug locally against a custom `agent_workspace` (session data landing in `~/cow`), confirmed hitting `GET /api/sessions` at pure startup no longer reproduces it, and confirmed the legacy-data warning fires for both a stale memory DB and a skills-only leftover while staying silent on a clean install.

**Automated**: `pytest tests/test_memory_global_config.py` — 8/8 passing. `pytest tests/` — 419 passed, 3 skipped, 0 failed. Every new test was checked against its own regression (fails without the fix, passes with it), not just run once green.

### Notes for Reviewer

- `bridge/agent_initializer.py`'s change is arguably redundant given the `app.py` startup fix alone closes the known bug — kept for standalone correctness (tests, non-`app.py` entrypoints), happy to drop it.
- No migration here by design (see Solution) — happy to open a separate issue for it if there's interest.
- There's no supported way to relocate `agent_workspace` anywhere (web console, Desktop, `cow` CLI) — it's manual and undocumented today. `cli/commands/backup.py` already has most of what a `cow workspace move <path>` command would need. Happy to open a separate issue for this too if there's interest.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #
