### PR TITLE
fix(security): validate per-file paths in cloud skill install

### DIFF
--- a/agent/skills/service.py
+++ b/agent/skills/service.py
@@ -55,6 +55,25 @@ class SkillService:
             )
         return skill_dir
 
+    @staticmethod
+    def _safe_file_path(root: str, rel_path: str) -> str:
+        """Resolve a skill file path and validate it stays inside ``root``.
+
+        The per-file paths in an add payload are attacker-controlled just like
+        the skill name, so they need the same containment check: entries such
+        as ``../../evil.py`` or ``/etc/cron.d/evil`` would otherwise write
+        outside the skills directory.
+
+        :raises ValueError: if the resolved path would escape ``root``.
+        """
+        dest = os.path.realpath(os.path.join(root, rel_path))
+        root = os.path.realpath(root)
+        if not dest.startswith(root + os.sep):
+            raise ValueError(
+                f"invalid skill file path (path traversal detected): {rel_path!r}"
+            )
+        return dest
+
     # ------------------------------------------------------------------
     # query
     # ------------------------------------------------------------------
@@ -142,7 +161,7 @@ class SkillService:
                 if not url or not rel_path:
                     logger.warning(f"[SkillService] add: skip invalid file entry {file_info}")
                     continue
-                dest = os.path.join(tmp_dir, rel_path)
+                dest = self._safe_file_path(tmp_dir, rel_path)
                 self._download_file(url, dest)
         except Exception:
             shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/agent/skills/service.py
+++ b/agent/skills/service.py
@@ -64,9 +64,13 @@ class SkillService:
         as ``../../evil.py`` or ``/etc/cron.d/evil`` would otherwise write
         outside the skills directory.
 
+        Backslashes are normalised to ``/`` first, so a Windows-style payload
+        is checked the same way on POSIX, where ``\\`` is a legal filename
+        character rather than a separator.
+
         :raises ValueError: if the resolved path would escape ``root``.
         """
-        dest = os.path.realpath(os.path.join(root, rel_path))
+        dest = os.path.realpath(os.path.join(root, rel_path.replace("\\", "/")))
         root = os.path.realpath(root)
         if not dest.startswith(root + os.sep):
             raise ValueError(

--- a/tests/test_security_ssrf_path_traversal.py
+++ b/tests/test_security_ssrf_path_traversal.py
@@ -202,5 +202,111 @@ class TestSkillServicePathTraversal(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
+class TestSkillServiceFilePathTraversal(unittest.TestCase):
+    """Test that the per-file paths in an add payload cannot escape the skills root.
+
+    The skill *name* is validated by _safe_skill_dir (issue #2873), but every
+    entry in ``payload["files"]`` also carries a ``path`` that is joined onto
+    the install directory, so it needs the same containment check.
+    """
+
+    def setUp(self):
+        self.tmp_root = tempfile.mkdtemp()
+        self.skills_root = os.path.join(self.tmp_root, "skills")
+        os.makedirs(self.skills_root)
+        from agent.skills.service import SkillService
+        mock_manager = MagicMock()
+        mock_manager.custom_dir = self.skills_root
+        self.svc = SkillService(mock_manager)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp_root, ignore_errors=True)
+
+    def _add_url_with_path(self, rel_path):
+        """Run _add_url with a single file entry, writing a marker to each dest."""
+        written = []
+
+        def fake_download(url, dest):
+            written.append(dest)
+            parent = os.path.dirname(dest)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(dest, "w") as f:
+                f.write("pwned")
+
+        with patch.object(self.svc, "_download_file", side_effect=fake_download):
+            self.svc._add_url("innocent", {
+                "name": "innocent",
+                "files": [{"url": "https://example.com/a", "path": rel_path}],
+            })
+        return written
+
+    def test_relative_file_path_allowed(self):
+        """A plain nested path stays inside the skill directory."""
+        written = self._add_url_with_path("scripts/run.py")
+        expected = os.path.realpath(
+            os.path.join(self.skills_root, "innocent.tmp", "scripts/run.py")
+        )
+        self.assertEqual([expected], [os.path.realpath(p) for p in written])
+        self.assertTrue(
+            os.path.exists(os.path.join(self.skills_root, "innocent", "scripts", "run.py"))
+        )
+
+    def test_dotdot_file_path_blocked(self):
+        """'../../escaped.py' must be rejected before anything is downloaded."""
+        with self.assertRaises(ValueError) as ctx:
+            self._add_url_with_path("../../escaped.py")
+        self.assertIn("path traversal", str(ctx.exception))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_root, "escaped.py")))
+
+    def test_backslash_file_path_blocked(self):
+        r"""'..\..\escaped.py' must be rejected (Windows separators)."""
+        with self.assertRaises(ValueError) as ctx:
+            self._add_url_with_path("..\\..\\escaped.py")
+        self.assertIn("path traversal", str(ctx.exception))
+
+    def test_absolute_posix_file_path_blocked(self):
+        """An absolute POSIX path must be rejected, not silently honoured."""
+        with self.assertRaises(ValueError) as ctx:
+            self._add_url_with_path("/tmp/cow-evil-marker.py")
+        self.assertIn("path traversal", str(ctx.exception))
+
+    def test_absolute_native_file_path_blocked(self):
+        """An absolute path outside the skills root must be rejected."""
+        outside = os.path.join(self.tmp_root, "outside", "evil.py")
+        with self.assertRaises(ValueError) as ctx:
+            self._add_url_with_path(outside)
+        self.assertIn("path traversal", str(ctx.exception))
+        self.assertFalse(os.path.exists(outside))
+
+    def test_midpath_dotdot_blocked(self):
+        """'sub/../../sibling.py' escapes the skill dir even while inside the root."""
+        with self.assertRaises(ValueError) as ctx:
+            self._add_url_with_path("sub/../../sibling.py")
+        self.assertIn("path traversal", str(ctx.exception))
+        self.assertFalse(os.path.exists(os.path.join(self.skills_root, "sibling.py")))
+
+    def test_traversal_aborts_before_download(self):
+        """No file is fetched at all when an entry is unsafe."""
+        calls = []
+
+        def fake_download(url, dest):
+            calls.append(url)
+
+        with patch.object(self.svc, "_download_file", side_effect=fake_download):
+            with self.assertRaises(ValueError):
+                self.svc._add_url("innocent", {
+                    "name": "innocent",
+                    "files": [{"url": "https://example.com/evil", "path": "../../evil.py"}],
+                })
+        self.assertEqual([], calls)
+
+    def test_safe_file_path_rejects_root_itself(self):
+        """A path resolving to the install dir itself is not a valid file target."""
+        with self.assertRaises(ValueError):
+            self.svc._safe_file_path(self.skills_root, ".")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #3005

`SkillService._add_url` validates the skill *name* through `_safe_skill_dir` — the guard added for #2873 — but the per-file `path` that arrives in the same cloud payload is joined onto the install directory untouched:

```python
skill_dir = self._safe_skill_dir(name)   # validated
tmp_dir = skill_dir + ".tmp"
...
dest = os.path.join(tmp_dir, rel_path)   # not validated
```

`os.path.join` throws away everything to its left the moment `rel_path` is absolute, and it never collapses `..`, so a single crafted file entry writes wherever the process can reach. `on_skill` in `common/cloud_client.py` forwards cloud `SKILL` messages straight into `dispatch("add", payload)`, so this sits behind the same trust boundary as #2873.

This adds `_safe_file_path`, which resolves the destination with `os.path.realpath` and rejects anything that is not strictly under the install root — the same shape as `_safe_extractall` in `cli/commands/skill.py:582`, reimplemented locally because `agent/` can't import from `cli/` (the dependency runs the other way round: `cli/utils.py:28`, `cli/commands/install.py:273`). The check runs before `_download_file`, so an unsafe entry aborts the install without fetching anything.

Measured with `custom_dir` at a temp skills root and the download stubbed to write a marker, installing skill `innocent` with one file entry:

| `files[].path` | before | after |
|---|---|---|
| `SKILL.md`, `scripts/run.py` | inside the skill dir | unchanged |
| `../../../ESCAPED/a.py` | **outside the skills root** | `ValueError`, no write |
| `..\..\..\ESCAPED_BS\b.py` | **outside the skills root** | `ValueError`, no write |
| `/abs/c.py` | **outside the skills root** | `ValueError`, no write |
| `D:/tmp/cow/ABS_WIN/d.py` | **outside the skills root** | `ValueError`, no write |
| `sub/../../ESCAPED_MID/e.py` | outside the skill dir | `ValueError`, no write |

Before the fix the install also logged success (`installed via url (1 files)`), and the existing `except Exception: shutil.rmtree(tmp_dir)` rollback did not clean up the escaped file — it was never under `tmp_dir`.

I left `_add_package` alone. It calls `zf.extractall(extract_dir)` with no member filtering, but it does not actually escape: `zipfile.extractall` sanitizes traversal member names itself, which I confirmed on 3.12.10 for `../../ESC/a`, `..\..\ESCBS\b`, `/abs/c`, `C:/abs/d` and `sub/../../ESCMID/e` — all land inside the destination. That path is safe incidentally rather than by intent, which seemed worth reporting in the issue but not worth changing in a security fix.

Eight tests in `TestSkillServiceFilePathTraversal` cover each escaping shape, that nothing is downloaded when an entry is unsafe, and that benign nested paths still install. Seven of them fail on `master` and pass with the fix; the eighth is the benign-path control that passes either way. The suite collects 578 → 586 (exactly the eight added) and the set of pre-existing failures is byte-identical before and after — 36 either way, all unrelated (dashscope, chrome singleton, browser).
