### PR TITLE
fix: preserve evolution eligibility when concurrency is full

### DIFF
--- a/agent/evolution/executor.py
+++ b/agent/evolution/executor.py
@@ -337,6 +337,11 @@ def run_evolution_for_session(
         if not agent:
             return False
 
+        # Consume the trigger only after this pass has secured a concurrency
+        # slot and resolved its session. Sessions rejected by the gate keep
+        # their accumulated turns and remain eligible for the next scan.
+        agent._evo_turns = 0
+
         with agent.messages_lock:
             all_messages = list(agent.messages)
         total_msgs = len(all_messages)

--- a/agent/evolution/trigger.py
+++ b/agent/evolution/trigger.py
@@ -142,10 +142,6 @@ def _scan_once(agent_bridge, cfg) -> None:
             channel_type = getattr(agent, "_evo_channel_type", "") or ""
             receiver = getattr(agent, "_evo_receiver", "") or ""
 
-            # Reset baseline BEFORE running so a long pass / new messages during
-            # it don't double-trigger; turns accrue fresh from here.
-            agent._evo_turns = 0
-
             run_evolution_for_session(
                 agent_bridge,
                 session_id=session_id,

--- a/tests/test_evolution_trigger.py
+++ b/tests/test_evolution_trigger.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import agent.evolution.executor as executor
+import agent.evolution.trigger as trigger
+
+
+class _FakeAgent:
+    def __init__(self, turns=3):
+        self.messages = []
+        self.messages_lock = threading.Lock()
+        self._evo_turns = turns
+        self._evo_last_active = time.time() - 60
+
+
+class _FakeBridge:
+    def __init__(self, agent):
+        self.agent = agent
+
+    def iter_agent_instances(self, include_defaults=False):
+        return [("default", "session-test", self.agent)]
+
+    def get_cached_agent(self, session_id, agent_id="default"):
+        return self.agent
+
+
+def _enabled_config():
+    return SimpleNamespace(enabled=True)
+
+
+class EvolutionTriggerConcurrencyTest(unittest.TestCase):
+    def test_busy_evolution_scan_preserves_trigger_turns(self):
+        agent = _FakeAgent(turns=3)
+        bridge = _FakeBridge(agent)
+        scan_config = SimpleNamespace(min_turns=1, idle_seconds=0)
+
+        with (
+            patch.object(executor, "get_evolution_config", _enabled_config),
+            patch.object(executor, "_running_count", executor._MAX_CONCURRENT),
+        ):
+            trigger._scan_once(bridge, scan_config)
+
+            self.assertEqual(agent._evo_turns, 3)
+            self.assertEqual(executor._running_count, executor._MAX_CONCURRENT)
+
+    def test_admitted_evolution_consumes_turns_and_releases_slot(self):
+        agent = _FakeAgent(turns=3)
+        bridge = _FakeBridge(agent)
+
+        with (
+            patch.object(executor, "get_evolution_config", _enabled_config),
+            patch.object(executor, "_running_count", 0),
+        ):
+            evolved = executor.run_evolution_for_session(bridge, "session-test")
+
+            self.assertFalse(evolved)
+            self.assertEqual(agent._evo_turns, 0)
+            self.assertEqual(executor._running_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Preserve a session's evolution trigger state when an evolution pass cannot
start because the concurrency limit is full.

## Why

The trigger previously reset `_evo_turns` before concurrency admission.
When all evolution slots were occupied, a skipped session lost its accumulated
turn count without being reviewed.

If its context was subsequently trimmed below the context-pressure threshold,
the session might no longer satisfy either trigger condition.

## Changes

- Move the `_evo_turns` reset from the scanner to the executor.
- Consume accumulated turns only after securing a concurrency slot and resolving
  the target agent.
- Add regression tests for rejected and admitted evolution passes.

## Testing

- `python tests/test_evolution_trigger.py`: 2 passed.
- Python syntax compilation: passed.
- Existing evolution stub scenarios: 13 core scenarios passed.
- The final existing undo check could not run in the local bundled environment
  because the `regex` dependency was unavailable.

Fixes #3010