### PR TITLE
feat: (web) add reliable SSE reconnection with event replay

### DIFF
--- a/agent/memory/conversation_store.py
+++ b/agent/memory/conversation_store.py
@@ -194,7 +194,9 @@ def _group_into_display_turns(
     include_thinking: bool = True,
 ) -> List[Dict[str, Any]]:
     """
-    Convert raw (role, content_json, created_at) DB rows into display turns.
+    Convert raw DB rows into display turns. Rows loaded for the web history
+    include ``seq`` as their first field; older callers may still pass the
+    legacy ``(role, content_json, created_at, extras)`` shape.
 
     One display turn = one visible user message  +  one merged assistant reply.
     All intermediate assistant messages (those carrying tool_use) and the final
@@ -220,7 +222,12 @@ def _group_into_display_turns(
     cur_rest: List[tuple] = []
     started = False
 
-    for role, raw_content, created_at, raw_extras in rows:
+    for row in rows:
+        if len(row) == 5:
+            seq, role, raw_content, created_at, raw_extras = row
+        else:
+            seq = None
+            role, raw_content, created_at, raw_extras = row
         try:
             content = json.loads(raw_content)
         except Exception:
@@ -235,11 +242,11 @@ def _group_into_display_turns(
         if role == "user" and _is_visible_user_message(content):
             if started:
                 groups.append((cur_user, cur_rest))
-            cur_user = (content, created_at, extras)
+            cur_user = (content, created_at, extras, seq)
             cur_rest = []
             started = True
         else:
-            cur_rest.append((role, content, created_at, extras))
+            cur_rest.append((role, content, created_at, extras, seq))
 
     if started:
         groups.append((cur_user, cur_rest))
@@ -252,13 +259,16 @@ def _group_into_display_turns(
     for user_row, rest in groups:
         # User turn
         if user_row:
-            content, created_at, _u_extras = user_row
+            content, created_at, _u_extras, user_seq = user_row
             text = _extract_display_text(content)
             # Hide internal injection markers (scheduler / self-evolution) so the
             # user never sees a synthetic "[SCHEDULED] self-evolution" bubble;
             # the assistant reply that follows is still rendered.
             if text and not _is_internal_user_marker(text):
-                turns.append({"role": "user", "content": text, "created_at": created_at})
+                turn = {"role": "user", "content": text, "created_at": created_at}
+                if user_seq is not None:
+                    turn["_seq"] = user_seq
+                turns.append(turn)
 
         # Build an ordered list of steps preserving the original sequence:
         #   thinking → content → tool_call → content → ...
@@ -266,9 +276,10 @@ def _group_into_display_turns(
         tool_results: Dict[str, str] = {}
         final_text = ""
         final_ts: Optional[int] = None
+        final_seq: Optional[int] = None
         merged_extras: Dict[str, Any] = {}
 
-        for role, content, created_at, extras in rest:
+        for role, content, created_at, extras, seq in rest:
             if role == "assistant" and isinstance(extras, dict):
                 merged_extras.update(extras)
             if role == "user":
@@ -302,6 +313,8 @@ def _group_into_display_turns(
                     steps.append({"type": "content", "content": content.strip()})
                     final_text = content.strip()
                 final_ts = created_at
+                if seq is not None:
+                    final_seq = seq
 
         # Attach tool results to tool steps
         for step in steps:
@@ -335,6 +348,8 @@ def _group_into_display_turns(
                 turn["kind"] = "evolution"
             if merged_extras:
                 turn["extras"] = merged_extras
+            if final_seq is not None:
+                turn["_seq"] = final_seq
             turns.append(turn)
 
     return turns
@@ -1045,33 +1060,7 @@ class ConversationStore:
         except Exception:
             include_thinking = False
 
-        # Strip seq for display grouping, but record max seq per visible user group
-        plain_rows = [
-            (role, content, created_at, extras_raw)
-            for _seq, role, content, created_at, extras_raw in rows
-        ]
-        visible = _group_into_display_turns(plain_rows, include_thinking=include_thinking)
-
-        # Build a mapping: find the seq of each visible user message to annotate context boundary.
-        # Walk through rows to find visible user message seqs in order.
-        visible_user_seqs: List[int] = []
-        for seq, role, raw_content, _ts, _extras in rows:
-            if role != "user":
-                continue
-            try:
-                content = json.loads(raw_content)
-            except Exception:
-                content = raw_content
-            if _is_visible_user_message(content):
-                visible_user_seqs.append(seq)
-
-        # Each pair of display turns (user+assistant) corresponds to a visible user seq.
-        # Mark which turns are before the context boundary.
-        user_turn_idx = 0
-        for turn in visible:
-            if turn["role"] == "user" and user_turn_idx < len(visible_user_seqs):
-                turn["_seq"] = visible_user_seqs[user_turn_idx]
-                user_turn_idx += 1
+        visible = _group_into_display_turns(rows, include_thinking=include_thinking)
 
         total = len(visible)
         offset = (page - 1) * page_size

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -1460,6 +1460,9 @@ let pollGeneration = 0;   // incremented on each restart to cancel stale poll lo
 let loadingContainers = {};
 let activeStreams = {};   // request_id -> EventSource
 let sessionActiveRequest = {};   // session_id -> request_id (in-flight stream per session)
+const PENDING_VOICE_ATTACH_TTL_MS = 2 * 60 * 1000;
+const PENDING_VOICE_ATTACH_MAX = 100;
+const pendingVoiceAttachments = new Map(); // session_id:bot_seq -> pending audio
 
 function isCurrentSessionConversationActive() {
     return !!sessionActiveRequest[sessionId];
@@ -3038,6 +3041,7 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
     let reasoningStartTime = 0;
     let done = false;
     let mainDone = false;
+    let completedBotSeq = null;
     let cancelled = false;
     let lastSeq = 0;
 
@@ -3388,6 +3392,9 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
                 // The answer is persisted, but async attachments may still
                 // follow. Only stream_end closes the request lifecycle.
                 mainDone = true;
+                if (item.bot_seq !== undefined && item.bot_seq !== null) {
+                    completedBotSeq = item.bot_seq;
+                }
                 settlePendingTools();
                 resetSendBtnSendMode();
 
@@ -3442,9 +3449,13 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
 
             } else if (item.type === 'voice_attach') {
                 // TTS finished — attach a playable audio element to the
-                // current bot bubble. The stream closes right after.
-                if (botEl && item.url) {
-                    attachAudioToBotBubble(botEl, item.url, { autoplay: true });
+                // persisted bot bubble. If history is still loading after a
+                // session switch, keep the attachment until that bubble exists.
+                if (item.url && completedBotSeq !== null) {
+                    rememberPendingVoiceAttachment(
+                        ownerSession, completedBotSeq, item.url
+                    );
+                    flushPendingVoiceAttachments(ownerSession, true);
                 }
 
             } else if (item.type === 'stream_end') {
@@ -3511,6 +3522,26 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
             }
             if (buffer.items.length < 5000) buffer.items.push(item);
             if (seq) lastSeq = seq;
+
+            // done is persisted before it is published. Remember that state
+            // even while this session is in the background, where rendering
+            // is intentionally skipped.
+            if (item.type === 'done') {
+                mainDone = true;
+                if (item.bot_seq !== undefined && item.bot_seq !== null) {
+                    completedBotSeq = item.bot_seq;
+                }
+            } else if (
+                item.type === 'voice_attach'
+                && item.url
+                && completedBotSeq !== null
+            ) {
+                // Background sessions skip rendering below. Preserve their
+                // attachment so loadHistory can mount it when the user returns.
+                rememberPendingVoiceAttachment(
+                    ownerSession, completedBotSeq, item.url
+                );
+            }
 
             // Background session: keep the stream alive so the reply finishes
             // and persists, but skip rendering into the now-foreign view. The
@@ -4020,6 +4051,53 @@ function attachAudioToBotBubble(botEl, audioUrl, opts) {
     } catch (_) { /* silent */ }
 }
 
+function pendingVoiceAttachmentKey(sid, botSeq) {
+    return `${sid}:${botSeq}`;
+}
+
+function rememberPendingVoiceAttachment(sid, botSeq, audioUrl) {
+    if (!sid || botSeq === undefined || botSeq === null || !audioUrl) return;
+    const key = pendingVoiceAttachmentKey(sid, botSeq);
+    const pending = {
+        sid,
+        botSeq: String(botSeq),
+        audioUrl,
+        expiresAt: Date.now() + PENDING_VOICE_ATTACH_TTL_MS,
+    };
+    pendingVoiceAttachments.delete(key);
+    pendingVoiceAttachments.set(key, pending);
+
+    while (pendingVoiceAttachments.size > PENDING_VOICE_ATTACH_MAX) {
+        pendingVoiceAttachments.delete(pendingVoiceAttachments.keys().next().value);
+    }
+    setTimeout(() => {
+        if (pendingVoiceAttachments.get(key) === pending) {
+            pendingVoiceAttachments.delete(key);
+        }
+    }, PENDING_VOICE_ATTACH_TTL_MS);
+}
+
+function flushPendingVoiceAttachments(sid, autoplay) {
+    if (!sid || sid !== sessionId) return 0;
+    const now = Date.now();
+    let attached = 0;
+    pendingVoiceAttachments.forEach((pending, key) => {
+        if (pending.expiresAt <= now) {
+            pendingVoiceAttachments.delete(key);
+            return;
+        }
+        if (pending.sid !== sid) return;
+        const botEl = Array.from(
+            messagesDiv.querySelectorAll('.bot-message-group[data-seq]')
+        ).find(el => el.dataset.seq === pending.botSeq);
+        if (!botEl) return;
+        attachAudioToBotBubble(botEl, pending.audioUrl, { autoplay: !!autoplay });
+        pendingVoiceAttachments.delete(key);
+        attached++;
+    });
+    return attached;
+}
+
 // Build a compact play/pause + progress + duration pill that wraps a
 // hidden <audio>. Returns the root element; safe to embed anywhere.
 function renderVoicePill(audioUrl, opts) {
@@ -4164,10 +4242,14 @@ function addBotMessage(content, timestamp, requestId) {
 function loadHistory(page) {
     if (historyLoading) return;
     historyLoading = true;
+    const historySessionId = sessionId;
 
-    fetch(`/api/history?session_id=${encodeURIComponent(sessionId)}&page=${page}&page_size=20`)
+    fetch(`/api/history?session_id=${encodeURIComponent(historySessionId)}&page=${page}&page_size=20`)
         .then(r => r.json())
         .then(data => {
+            // A response from a session we have since left must never render
+            // into the new session's message list.
+            if (historySessionId !== sessionId) return;
             if (data.status !== 'success' || data.messages.length === 0) return;
 
             const prevScrollHeight = messagesDiv.scrollHeight;
@@ -4227,6 +4309,12 @@ function loadHistory(page) {
             const insertBefore = sentinel ? sentinel.nextSibling : messagesDiv.firstChild;
             messagesDiv.insertBefore(fragment, insertBefore);
             updateEditButtonsState();
+            // A background voice_attach can arrive before this history
+            // fragment creates its target bubble. Retry now that seq metadata
+            // is present in the DOM; do not autoplay delayed attachments.
+            if (isFirstLoad) {
+                flushPendingVoiceAttachments(historySessionId, false);
+            }
 
             // Manage the "load more" sentinel at the very top
             if (data.has_more) {
@@ -4665,6 +4753,14 @@ function _reattachStream(sid) {
         if (oldEs) { try { oldEs.close(); } catch (_) {} delete activeStreams[requestId]; }
         delete streamBuffers[requestId];
         delete sessionActiveRequest[sid];
+        resetSendBtnSendMode();
+        return false;
+    }
+
+    // done already exists in persistent history. Keep the background tail
+    // connected for voice_attach/stream_end, but do not replay the answer into
+    // the freshly loaded history view or it would create a duplicate bubble.
+    if (buffer.items.some(it => it.type === 'done')) {
         resetSendBtnSendMode();
         return false;
     }

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -3037,7 +3037,9 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
     let reasoningText = '';
     let reasoningStartTime = 0;
     let done = false;
+    let mainDone = false;
     let cancelled = false;
+    let lastSeq = 0;
 
     // A stream can end while tools are still marked in-flight (cancel, dropped
     // connection). Settle them so nothing spins forever.
@@ -3383,13 +3385,10 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
                 resetSendBtnSendMode();
 
             } else if (item.type === 'done') {
-                // Don't close the stream yet: the backend keeps it open
-                // for a short tail to deliver async attachments such as
-                // TTS audio (`voice_attach`). It will close the stream on
-                // its own via onerror once the tail expires.
-                done = true;
+                // The answer is persisted, but async attachments may still
+                // follow. Only stream_end closes the request lifecycle.
+                mainDone = true;
                 settlePendingTools();
-                clearOwnerRequest();
                 resetSendBtnSendMode();
 
                 const finalTextRaw = item.content || accumulatedText;
@@ -3447,9 +3446,27 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
                 if (botEl && item.url) {
                     attachAudioToBotBubble(botEl, item.url, { autoplay: true });
                 }
+
+            } else if (item.type === 'stream_end') {
+                done = true;
                 if (currentEs) { currentEs.close(); }
                 delete activeStreams[requestId];
                 clearOwnerRequest();
+
+            } else if (item.type === 'resync_required') {
+                done = true;
+                settlePendingTools();
+                if (currentEs) { currentEs.close(); }
+                delete activeStreams[requestId];
+                clearOwnerRequest();
+                resetSendBtnSendMode();
+                if (isActive()) {
+                    messagesDiv.innerHTML = '';
+                    historyPage = 0;
+                    historyHasMore = false;
+                    historyLoading = false;
+                    loadHistory(1);
+                }
 
             } else if (item.type === 'error') {
                 done = true;
@@ -3466,13 +3483,19 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
     }
 
     function connect() {
-        const es = new EventSource(`/stream?request_id=${encodeURIComponent(requestId)}`);
+        const es = new EventSource(
+            `/stream?request_id=${encodeURIComponent(requestId)}`
+            + `&after_seq=${lastSeq}`
+        );
         currentEs = es;
         activeStreams[requestId] = es;
 
         es.onmessage = function(e) {
             let item;
             try { item = JSON.parse(e.data); } catch (_) { return; }
+
+            const seq = Number(item.seq || 0);
+            if (seq && seq <= lastSeq) return;
 
             // Successful data received, reset reconnect counter
             reconnectCount = 0;
@@ -3487,13 +3510,14 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
                 if (previousIndex >= 0) buffer.items.splice(previousIndex, 1);
             }
             if (buffer.items.length < 5000) buffer.items.push(item);
+            if (seq) lastSeq = seq;
 
             // Background session: keep the stream alive so the reply finishes
             // and persists, but skip rendering into the now-foreign view. The
             // buffer above still grows so returning to the session can rebuild
             // the bubble and resume live rendering.
             if (ownerSession !== sessionId) {
-                if (item.type === 'done' || item.type === 'error' || item.type === 'voice_attach') {
+                if (item.type === 'stream_end' || item.type === 'error' || item.type === 'resync_required') {
                     done = true;
                     es.close();
                     delete activeStreams[requestId];
@@ -3510,11 +3534,11 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
             delete activeStreams[requestId];
 
             if (done) {
-                // Normal close after the post-done tail expired; nothing to do.
+                // stream_end or an unrecoverable event already closed it.
                 return;
             }
 
-            if (cancelled) {
+            if (cancelled && !mainDone) {
                 // The user stopped the run, so the stream ending here is the
                 // expected outcome. Reconnecting would only land on a queue
                 // the backend has already reclaimed.
@@ -3563,8 +3587,10 @@ function startSSE(requestId, loadingEl, timestamp, titleInfo, replayItems) {
     // snapshot matches exactly what live rendering would have produced.
     if (replayItems && replayItems.length) {
         for (const item of replayItems) {
+            const seq = Number(item.seq || 0);
+            if (seq > lastSeq) lastSeq = seq;
             try { processSSEItem(item); } catch (_) {}
-            if (item.type === 'done' || item.type === 'error' || item.type === 'voice_attach') {
+            if (item.type === 'stream_end' || item.type === 'error' || item.type === 'resync_required') {
                 done = true;
             }
         }
@@ -4619,7 +4645,7 @@ function _onSessionListScroll() {
 // Returning to a session whose reply is still streaming in the background.
 // Close the background EventSource, rebuild the bubble from the buffered
 // events (snapshot), then resume live streaming via a fresh connection that
-// reads the remaining tail from the backend queue. Returns true if a stream
+// reads the remaining tail from the backend replay log. Returns true if a stream
 // was re-attached. The user's own bubble is already in history (persisted
 // eagerly), so it was rendered by loadHistory before this runs.
 function _reattachStream(sid) {
@@ -4632,7 +4658,7 @@ function _reattachStream(sid) {
     // persisted and rendered by loadHistory — re-attaching would duplicate it.
     // Just clean up the buffer/cursor and rely on history.
     const finished = buffer.items.some(
-        it => it.type === 'done' || it.type === 'error'
+        it => it.type === 'stream_end' || it.type === 'error' || it.type === 'resync_required'
     );
     if (finished) {
         const oldEs = activeStreams[requestId];
@@ -4643,9 +4669,8 @@ function _reattachStream(sid) {
         return false;
     }
 
-    // Stop the background stream so the rebuilt one is the sole consumer of
-    // the backend queue (the queue survives until "done", so the new
-    // connection picks up any remaining events).
+    // Stop the background connection before rebuilding. Each new connection
+    // resumes independently from its last accepted sequence number.
     const oldEs = activeStreams[requestId];
     if (oldEs) { try { oldEs.close(); } catch (_) {} delete activeStreams[requestId]; }
 

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -13,8 +13,10 @@ import threading
 import time
 import uuid
 from queue import Queue, Empty
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from urllib.parse import quote
+from collections import OrderedDict, deque
+from dataclasses import dataclass, field
 
 import web
 
@@ -22,7 +24,6 @@ from bridge.context import *
 from bridge.reply import Reply, ReplyType
 from channel.chat_channel import ChatChannel, check_prefix
 from channel.chat_message import ChatMessage
-from collections import OrderedDict
 from common import const
 from common import i18n
 from common.log import logger
@@ -32,6 +33,21 @@ from models.reasoning_capabilities import provider_reasoning_metadata
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
 VIDEO_EXTENSIONS = {".mp4", ".webm", ".avi", ".mov", ".mkv"}
+
+
+@dataclass
+class SSEStreamState:
+    """Bounded, replayable event log for one web request."""
+
+    condition: threading.Condition = field(default_factory=threading.Condition)
+    events: deque = field(default_factory=deque)
+    next_seq: int = 1
+    total_bytes: int = 0
+    last_active: float = field(default_factory=time.time)
+    main_done: bool = False
+    stream_complete: bool = False
+    completed_at: Optional[float] = None
+    closed: bool = False
 
 def _read_config_file_for_write() -> dict:
     """Baseline dict for a partial write to config.json.
@@ -538,6 +554,9 @@ class WebMessage(ChatMessage):
 class WebChannel(ChatChannel):
     NOT_SUPPORT_REPLYTYPE = [ReplyType.VOICE]
     _instance = None
+    SSE_REPLAY_MAX_EVENTS = 5000
+    SSE_REPLAY_MAX_BYTES = 4 * 1024 * 1024
+    SSE_COMPLETED_TTL_SECONDS = 300
 
     # def __new__(cls):
     #     if cls._instance is None:
@@ -550,12 +569,8 @@ class WebChannel(ChatChannel):
         self.session_queues = {}  # session_id -> Queue (fallback polling)
         self.request_to_session = {}  # request_id -> session_id
         self.request_to_agent = {}  # request_id -> agent_id
-        self.sse_queues = {}  # request_id -> Queue (SSE streaming)
-        # request_id -> last-active timestamp. Refreshed while the SSE
-        # generator is being consumed (client still connected). The janitor
-        # only reclaims queues whose generator stopped refreshing this, so a
-        # long-running but still-streaming reply is never wrongly killed.
-        self.sse_last_active = {}
+        self.sse_streams = {}  # request_id -> SSEStreamState
+        self._sse_streams_lock = threading.RLock()
         self._http_server = None
         self._sse_janitor_started = False
 
@@ -567,6 +582,44 @@ class WebChannel(ChatChannel):
     def _generate_request_id(self):
         """生成唯一的请求ID"""
         return str(uuid.uuid4())
+
+    def _publish_sse_event(self, request_id: str, event: dict) -> bool:
+        """Append one sequenced event and wake every connected reader."""
+        with self._sse_streams_lock:
+            state = self.sse_streams.get(request_id)
+        if state is None:
+            return False
+
+        with state.condition:
+            if state.closed or state.stream_complete:
+                return False
+            item = dict(event)
+            item["seq"] = state.next_seq
+            state.next_seq += 1
+            encoded_size = len(json.dumps(
+                item, ensure_ascii=False, separators=(",", ":")
+            ).encode("utf-8"))
+            state.events.append((item, encoded_size))
+            state.total_bytes += encoded_size
+            state.last_active = time.time()
+
+            # Keep at least the newest event even if it alone exceeds the byte
+            # budget. Cursor expiry is reported explicitly by stream_response.
+            while len(state.events) > 1 and (
+                len(state.events) > self.SSE_REPLAY_MAX_EVENTS
+                or state.total_bytes > self.SSE_REPLAY_MAX_BYTES
+            ):
+                _, removed_size = state.events.popleft()
+                state.total_bytes -= removed_size
+
+            event_type = item.get("type")
+            if event_type == "done":
+                state.main_done = True
+            elif event_type == "stream_end":
+                state.stream_complete = True
+                state.completed_at = state.last_active
+            state.condition.notify_all()
+        return True
 
     @staticmethod
     def _session_queue_key(session_id: str, agent_id: str = None) -> str:
@@ -620,14 +673,14 @@ class WebChannel(ChatChannel):
             agent_id = context.get("agent_id") or self.request_to_agent.get(request_id)
             session_queue_key = self._session_queue_key(session_id, agent_id)
 
-            # SSE mode: push events to SSE queue
-            if request_id in self.sse_queues:
+            # SSE mode: append events to the replay log.
+            if request_id in self.sse_streams:
                 content = reply.content if reply.content is not None else ""
 
                 # Intermediate status lines (e.g. /install-browser phases) must NOT use "done",
                 # or the frontend closes EventSource and drops subsequent events.
                 if getattr(reply, "sse_phase", False):
-                    self.sse_queues[request_id].put({
+                    self._publish_sse_event(request_id, {
                         "type": "phase",
                         "content": content,
                         "request_id": request_id,
@@ -644,7 +697,7 @@ class WebChannel(ChatChannel):
                         seqs = self._fetch_latest_pair_seqs(
                             session_id, context.get("agent_id")
                         )
-                        self.sse_queues[request_id].put({
+                        self._publish_sse_event(request_id, {
                             "type": "done",
                             "content": text_content,
                             "request_id": request_id,
@@ -652,6 +705,7 @@ class WebChannel(ChatChannel):
                             "user_seq": seqs.get("user_seq"),
                             "bot_seq": seqs.get("bot_seq"),
                         })
+                    self._publish_sse_event(request_id, {"type": "stream_end"})
                     logger.debug(f"SSE skipped duplicate file for request {request_id}")
                     return
 
@@ -665,7 +719,7 @@ class WebChannel(ChatChannel):
                 seqs = self._fetch_latest_pair_seqs(
                     session_id, context.get("agent_id")
                 )
-                self.sse_queues[request_id].put({
+                self._publish_sse_event(request_id, {
                     "type": "done",
                     "content": content,
                     "request_id": request_id,
@@ -678,8 +732,13 @@ class WebChannel(ChatChannel):
                 # synthesis runs in the background so the chat stream is never
                 # blocked; the resulting audio URL is pushed via a follow-up
                 # `voice_attach` SSE event and persisted to messages.extras.
+                tts_pending = False
                 if reply.type == ReplyType.TEXT and content.strip():
-                    self._maybe_dispatch_auto_tts(request_id, session_id, content, context)
+                    tts_pending = self._maybe_dispatch_auto_tts(
+                        request_id, session_id, content, context
+                    )
+                if not tts_pending:
+                    self._publish_sse_event(request_id, {"type": "stream_end"})
                 return
 
             # Fallback: polling mode
@@ -689,7 +748,7 @@ class WebChannel(ChatChannel):
                 # request: they were already pushed via the `file_to_send` event during
                 # agent execution. By the time the chat_channel sends the IMAGE_URL reply,
                 # the SSE stream has typically closed (after the text "done") and the
-                # request_id is gone from sse_queues, so we'd otherwise duplicate the file
+                # request_id is gone from sse_streams, so we'd otherwise duplicate the file
                 # as a polling bubble. Scheduler/push tasks have no on_event and must
                 # still go through polling normally.
                 if (
@@ -721,7 +780,7 @@ class WebChannel(ChatChannel):
             logger.error(f"Error in send method: {e}")
 
     def _make_sse_callback(self, request_id: str):
-        """Build an on_event callback that pushes agent stream events into the SSE queue."""
+        """Build a callback that publishes agent events to the SSE replay log."""
 
         # Cap reasoning bytes pushed to the frontend per request to avoid
         # browser stalls / crashes on very long chains-of-thought. Anything
@@ -742,9 +801,9 @@ class WebChannel(ChatChannel):
         streamed_error: List[str] = []
 
         def on_event(event: dict):
-            if request_id not in self.sse_queues:
+            if request_id not in self.sse_streams:
                 return
-            q = self.sse_queues[request_id]
+            publish = lambda item: self._publish_sse_event(request_id, item)
             event_type = event.get("type")
             data = event.get("data", {})
 
@@ -756,7 +815,7 @@ class WebChannel(ChatChannel):
                 if remaining <= 0:
                     if not reasoning_capped_notified[0]:
                         reasoning_capped_notified[0] = True
-                        q.put({
+                        publish({
                             "type": "reasoning",
                             "content": "\n\n... [reasoning truncated for display] ...",
                         })
@@ -764,20 +823,20 @@ class WebChannel(ChatChannel):
                 if len(delta) > remaining:
                     delta = delta[:remaining]
                 reasoning_chars_sent[0] += len(delta)
-                q.put({"type": "reasoning", "content": delta})
+                publish({"type": "reasoning", "content": delta})
 
             elif event_type == "message_update":
                 delta = data.get("delta", "")
                 if delta:
-                    q.put({"type": "delta", "content": delta})
+                    publish({"type": "delta", "content": delta})
 
             elif event_type == "tool_execution_start":
                 tool_name = data.get("tool_name", "tool")
                 arguments = data.get("arguments", {})
-                q.put({"type": "tool_start", "tool_call_id": data.get("tool_call_id"), "tool": tool_name, "arguments": arguments})
+                publish({"type": "tool_start", "tool_call_id": data.get("tool_call_id"), "tool": tool_name, "arguments": arguments})
 
             elif event_type == "tool_execution_progress":
-                q.put({
+                publish({
                     "type": "tool_progress",
                     "tool_call_id": data.get("tool_call_id"),
                     "tool": data.get("tool_name", "tool"),
@@ -810,13 +869,13 @@ class WebChannel(ChatChannel):
                     if len(display) > MAX_DISPLAY_STREAM_CHARS:
                         display = display[:MAX_DISPLAY_STREAM_CHARS] + "…"
                     payload["display"] = display
-                q.put(payload)
+                publish(payload)
 
             elif event_type == "subagent_step":
                 # A tool call made by a sub agent, relayed so the card for
                 # that sub agent can show what it is doing instead of
                 # spinning for minutes.
-                q.put({
+                publish({
                     "type": "subagent_step",
                     "card_id": data.get("card_id"),
                     "step_id": data.get("step_id"),
@@ -831,7 +890,7 @@ class WebChannel(ChatChannel):
             elif event_type == "message_end":
                 tool_calls = data.get("tool_calls", [])
                 if tool_calls:
-                    q.put({"type": "message_end", "has_tool_calls": True})
+                    publish({"type": "message_end", "has_tool_calls": True})
 
             elif event_type == "error":
                 # Agent raised an exception (LLM 401/timeout/etc). Surface the
@@ -845,19 +904,20 @@ class WebChannel(ChatChannel):
                 # Remember it so the agent_end handler below knows not to
                 # rewrite the message into a generic empty-response notice.
                 streamed_error.append(err_msg)
-                q.put({
+                publish({
                     "type": "done",
                     "content": f"❌ {err_msg}",
                     "request_id": request_id,
                     "timestamp": time.time(),
                 })
+                publish({"type": "stream_end"})
 
             elif event_type == "agent_cancelled":
                 # Push an explicit cancelled SSE event so the frontend
                 # marks the bubble as stopped. A trailing "done" still
                 # arrives with the partial answer.
                 final_response = data.get("final_response", "")
-                q.put({
+                publish({
                     "type": "cancelled",
                     "content": final_response,
                     "request_id": request_id,
@@ -881,7 +941,7 @@ class WebChannel(ChatChannel):
                             f"[WebChannel] agent_end with empty final_response for "
                             f"request {request_id}, sending fallback done"
                         )
-                        q.put({
+                        publish({
                             "type": "done",
                             "content": i18n.t(
                                 "(模型未返回任何内容，请重试或换一种方式描述你的需求)",
@@ -890,6 +950,7 @@ class WebChannel(ChatChannel):
                             "request_id": request_id,
                             "timestamp": time.time(),
                         })
+                        publish({"type": "stream_end"})
 
             elif event_type == "file_to_send":
                 file_path = data.get("path", "")
@@ -917,12 +978,12 @@ class WebChannel(ChatChannel):
                 # the file directly (Finder / default app) instead of the browser.
                 if not is_remote and file_path:
                     payload["abs_path"] = file_path
-                q.put(payload)
+                publish(payload)
 
             elif event_type == "artifact":
                 payload = _build_artifact_payload(data)
                 if payload:
-                    q.put(payload)
+                    publish(payload)
 
         return on_event
 
@@ -970,22 +1031,24 @@ class WebChannel(ChatChannel):
         session_id: str,
         text: str,
         context: dict,
-    ) -> None:
+    ) -> bool:
         try:
             mode = self._resolve_voice_reply_mode()
             if mode == "off":
-                return
+                return False
             if mode == "voice_if_voice" and not context.get("is_voice_input"):
-                return
+                return False
             if not self._tts_provider_ready():
-                return
+                return False
             threading.Thread(
                 target=self._synthesize_tts_async,
                 args=(request_id, session_id, text, context.get("agent_id")),
                 daemon=True,
             ).start()
+            return True
         except Exception as e:
             logger.debug(f"[WebChannel] auto-tts dispatch skipped: {e}")
+            return False
 
     def _synthesize_tts_async(
         self,
@@ -1017,14 +1080,13 @@ class WebChannel(ChatChannel):
                 ).attach_extras_to_last_assistant(session_id, payload)
             except Exception as e:
                 logger.debug(f"[WebChannel] tts persist skipped: {e}")
-            q = self.sse_queues.get(request_id)
-            if q is None:
+            if request_id not in self.sse_streams:
                 logger.warning(
-                    f"[WebChannel] TTS ready but SSE queue already closed "
+                    f"[WebChannel] TTS ready but SSE stream already closed "
                     f"for request {request_id} (url={url})"
                 )
                 return
-            q.put({
+            self._publish_sse_event(request_id, {
                 "type": "voice_attach",
                 "url": url,
                 "request_id": request_id,
@@ -1034,6 +1096,8 @@ class WebChannel(ChatChannel):
         except Exception as e:
             # TTS failures are intentionally silent (no user-facing error).
             logger.warning(f"[WebChannel] TTS synthesis failed: {e}")
+        finally:
+            self._publish_sse_event(request_id, {"type": "stream_end"})
 
     @staticmethod
     def _publish_tts_audio(src_path: str) -> str:
@@ -1329,8 +1393,8 @@ class WebChannel(ChatChannel):
                 self.session_queues[session_queue_key] = Queue()
 
             if use_sse:
-                self.sse_queues[request_id] = Queue()
-                self.sse_last_active[request_id] = time.time()
+                with self._sse_streams_lock:
+                    self.sse_streams[request_id] = SSEStreamState()
 
             trigger_prefixs = conf().get("single_chat_prefix", [""])
             if check_prefix(prompt, trigger_prefixs) is None:
@@ -1370,30 +1434,21 @@ class WebChannel(ChatChannel):
             return json.dumps({"status": "error", "message": str(e)})
 
     def _drop_sse_request(self, request_id: str):
-        """Reclaim all state tied to an SSE request to prevent fd/memory leaks.
-
-        Removing the queue lets the WSGI generator and its socket be released,
-        and dropping request_to_session avoids unbounded map growth.
-        """
-        self.sse_queues.pop(request_id, None)
-        self.sse_last_active.pop(request_id, None)
-        self.request_to_session.pop(request_id, None)
-        self.request_to_agent.pop(request_id, None)
+        """Reclaim all state tied to an SSE request."""
+        with self._sse_streams_lock:
+            state = self.sse_streams.pop(request_id, None)
+            self.request_to_session.pop(request_id, None)
+            self.request_to_agent.pop(request_id, None)
+        if state is not None:
+            with state.condition:
+                state.closed = True
+                state.condition.notify_all()
 
     def _start_sse_janitor(self):
-        """Start a background thread that reclaims orphaned SSE queues.
+        """Start a background thread that reclaims orphaned SSE logs.
 
-        When a client disconnects before the "done" event arrives (browser
-        closed, session switched, network drop), the generator may keep the
-        queue around to allow reconnection. Without a sweep these orphans
-        accumulate, leaking file descriptors until cheroot raises
-        "[Errno 24] Too many open files".
-
-        Reclamation is based on idle time, not total age: an active stream
-        refreshes ``sse_last_active`` every second while its generator is being
-        consumed, so a long-running reply (even hours long) is never killed
-        while the client stays connected. Only queues that stopped refreshing
-        (client gone) past SSE_IDLE_TIMEOUT are reclaimed.
+        Completed logs remain replayable for a short grace period. Abandoned
+        unfinished logs use the longer idle timeout.
         """
         if self._sse_janitor_started:
             return
@@ -1407,10 +1462,20 @@ class WebChannel(ChatChannel):
                 time.sleep(SWEEP_INTERVAL)
                 try:
                     now = time.time()
-                    stale = [
-                        rid for rid, ts in list(self.sse_last_active.items())
-                        if now - ts > SSE_IDLE_TIMEOUT
-                    ]
+                    with self._sse_streams_lock:
+                        states = list(self.sse_streams.items())
+                    stale = []
+                    for rid, state in states:
+                        with state.condition:
+                            if state.stream_complete and state.completed_at:
+                                expired = (
+                                    now - state.completed_at
+                                    > self.SSE_COMPLETED_TTL_SECONDS
+                                )
+                            else:
+                                expired = now - state.last_active > SSE_IDLE_TIMEOUT
+                        if expired:
+                            stale.append(rid)
                     for rid in stale:
                         self._drop_sse_request(rid)
                     if stale:
@@ -1424,91 +1489,93 @@ class WebChannel(ChatChannel):
         t = threading.Thread(target=_sweep, name="sse-janitor", daemon=True)
         t.start()
 
-    def stream_response(self, request_id: str):
+    def stream_response(self, request_id: str, after_seq: int = 0):
         """
         SSE generator for a given request_id.
         Yields UTF-8 encoded bytes to avoid WSGI Latin-1 mangling.
-        Supports client reconnection: the queue is only removed after a
-        "done" event is consumed, so a new GET /stream with the same
-        request_id can resume reading remaining events.
+        Each connection reads the request's event log using its own cursor.
         """
-        if request_id not in self.sse_queues:
+        with self._sse_streams_lock:
+            state = self.sse_streams.get(request_id)
+        if state is None:
             yield b"data: {\"type\": \"error\", \"message\": \"invalid request_id\"}\n\n"
             return
-
-        q = self.sse_queues[request_id]
+        try:
+            cursor = max(0, int(after_seq))
+        except (TypeError, ValueError):
+            cursor = 0
         idle_timeout = 600  # 10 minutes without any real event
         deadline = time.time() + idle_timeout
-        # After the main reply is done we keep the stream open for a short
-        # tail so async post-processing (TTS auto-synthesis) can deliver a
-        # `voice_attach` event before the client disconnects.
-        POST_DONE_TAIL_SECONDS = 60
         # A cancel only takes effect at the agent's next checkpoint, so the run
         # keeps emitting events (tool results, the partial reply) for a while
         # after the user presses Stop. Stay open for them, just not for the
         # full idle timeout.
         CANCEL_GRACE_SECONDS = 60
-        POST_CANCEL_TAIL_SECONDS = 3
-        post_done = False
-        post_deadline = 0.0
         cancelled = False
 
         try:
             while time.time() < deadline:
-                # Mark the stream alive on every loop. While the client keeps
-                # consuming, the generator runs and refreshes this, so the
-                # janitor won't reclaim a long-running but active stream.
-                self.sse_last_active[request_id] = time.time()
-                try:
-                    item = q.get(timeout=1)
-                except Empty:
-                    if post_done and time.time() >= post_deadline:
+                resync_payload = None
+                with state.condition:
+                    state.last_active = time.time()
+                    if state.events:
+                        first_seq = state.events[0][0]["seq"]
+                        latest_seq = state.events[-1][0]["seq"]
+                        if cursor < first_seq - 1:
+                            resync_payload = {
+                                "type": "resync_required",
+                                "reason": "event_cursor_expired",
+                                "after_seq": cursor,
+                                "first_available_seq": first_seq,
+                            }
+                        elif cursor > latest_seq:
+                            resync_payload = {
+                                "type": "resync_required",
+                                "reason": "event_cursor_ahead",
+                                "after_seq": cursor,
+                                "latest_available_seq": latest_seq,
+                            }
+                    pending = [
+                        event for event, _ in state.events
+                        if event["seq"] > cursor
+                    ]
+                    complete = state.stream_complete
+                    closed = state.closed
+                    if (
+                        resync_payload is None
+                        and not pending and not complete and not closed
+                    ):
+                        state.condition.wait(timeout=1)
+
+                if resync_payload is not None:
+                    payload = json.dumps(resync_payload, ensure_ascii=False)
+                    yield f"data: {payload}\n\n".encode("utf-8")
+                    return
+
+                if not pending:
+                    if complete or closed:
                         break
                     yield b": keepalive\n\n"
                     continue
 
-                deadline = time.time() + (
-                    CANCEL_GRACE_SECONDS if cancelled else idle_timeout
-                )
-                payload = json.dumps(item, ensure_ascii=False)
-                yield f"data: {payload}\n\n".encode("utf-8")
-
-                itype = item.get("type")
-                if itype == "done":
-                    post_done = True
-                    post_deadline = time.time() + (
-                        POST_CANCEL_TAIL_SECONDS if cancelled
-                        else POST_DONE_TAIL_SECONDS
+                for item in pending:
+                    deadline = time.time() + (
+                        CANCEL_GRACE_SECONDS if cancelled else idle_timeout
                     )
-                elif itype == "cancelled":
-                    # Wait for the run to actually wind down and send its
-                    # partial reply as "done"; closing on a blind timer here
-                    # strands in-flight tool bubbles and makes the client
-                    # reconnect onto a dropped queue.
-                    cancelled = True
-                    deadline = time.time() + CANCEL_GRACE_SECONDS
-                elif itype == "voice_attach":
-                    # WSGI buffers the previous chunk until the next yield;
-                    # shrink the tail so the generator wakes up quickly to
-                    # emit a couple of keepalive comments that push the
-                    # voice_attach payload through to the browser.
-                    post_done = True
-                    post_deadline = time.time() + 2  # 2s post-attach tail
+                    payload = json.dumps(item, ensure_ascii=False)
+                    yield (
+                        f"id: {item['seq']}\n"
+                        f"data: {payload}\n\n"
+                    ).encode("utf-8")
+                    cursor = item["seq"]
+                    if item.get("type") == "cancelled":
+                        cancelled = True
+                        deadline = time.time() + CANCEL_GRACE_SECONDS
+                    if item.get("type") == "stream_end":
+                        return
         except GeneratorExit:
-            # Client disconnected (WSGI closed the generator). If the reply is
-            # already complete there is nothing to resume, so reclaim now to
-            # release the socket fd. Otherwise keep the queue briefly so a
-            # reconnect with the same request_id can resume; the janitor will
-            # reclaim it if no reconnect happens.
-            if post_done:
-                self._drop_sse_request(request_id)
+            # The event log is deliberately retained for reconnection.
             raise
-        finally:
-            # Drop the queue once the reply is actually complete or the idle
-            # deadline has passed. Early client disconnects are handled by the
-            # GeneratorExit branch above and the background janitor.
-            if post_done or time.time() >= deadline:
-                self._drop_sse_request(request_id)
 
     def cancel_request(self):
         """
@@ -1556,8 +1623,8 @@ class WebChannel(ChatChannel):
                 )
                 cancelled = registry.cancel_session(scoped_session_id)
 
-            if request_id and request_id in self.sse_queues:
-                self.sse_queues[request_id].put({
+            if request_id and request_id in self.sse_streams:
+                self._publish_sse_event(request_id, {
                     "type": "cancelled",
                     "content": "🛑 Cancelled" if lang.startswith("en") else "🛑 已中止",
                     "request_id": request_id,
@@ -1780,7 +1847,7 @@ class WebChannel(ChatChannel):
         server.requests.min = 20
         server.requests.max = 80
         self._http_server = server
-        # Reclaim orphaned SSE queues so disconnected clients don't leak fds.
+        # Reclaim orphaned SSE logs so disconnected clients don't leak memory.
         self._start_sse_janitor()
         try:
             server.start()
@@ -2189,17 +2256,28 @@ class CancelHandler:
 class StreamHandler:
     def GET(self):
         _require_auth()
-        params = web.input(request_id='')
+        params = web.input(request_id='', after_seq='')
         request_id = params.request_id
         if not request_id:
             raise web.badrequest()
+
+        # Explicit query cursors are used by the frontend's manually-created
+        # EventSource. Native EventSource reconnects remain compatible via the
+        # standard Last-Event-ID request header.
+        raw_after_seq = params.after_seq
+        if raw_after_seq in (None, ''):
+            raw_after_seq = web.ctx.env.get('HTTP_LAST_EVENT_ID', '0')
+        try:
+            after_seq = max(0, int(raw_after_seq or 0))
+        except (TypeError, ValueError):
+            after_seq = 0
 
         web.header('Content-Type', 'text/event-stream; charset=utf-8')
         web.header('Cache-Control', 'no-cache')
         web.header('X-Accel-Buffering', 'no')
         web.header('Access-Control-Allow-Origin', '*')
 
-        return WebChannel().stream_response(request_id)
+        return WebChannel().stream_response(request_id, after_seq)
 
 
 class ChatHandler:

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -45,9 +45,21 @@ class SSEStreamState:
     total_bytes: int = 0
     last_active: float = field(default_factory=time.time)
     main_done: bool = False
+    main_done_at: Optional[float] = None
     stream_complete: bool = False
     completed_at: Optional[float] = None
     closed: bool = False
+
+
+def _parse_sse_cursor(*values) -> int:
+    cursors = []
+    for value in values:
+        try:
+            cursors.append(max(0, int(value or 0)))
+        except (TypeError, ValueError):
+            cursors.append(0)
+    return max(cursors, default=0)
+
 
 def _read_config_file_for_write() -> dict:
     """Baseline dict for a partial write to config.json.
@@ -556,7 +568,9 @@ class WebChannel(ChatChannel):
     _instance = None
     SSE_REPLAY_MAX_EVENTS = 5000
     SSE_REPLAY_MAX_BYTES = 4 * 1024 * 1024
-    SSE_COMPLETED_TTL_SECONDS = 300
+    SSE_POST_DONE_TAIL_SECONDS = 60
+    SSE_COMPLETED_TTL_SECONDS = 60
+    SSE_IDLE_TIMEOUT_SECONDS = 1800
 
     # def __new__(cls):
     #     if cls._instance is None:
@@ -588,10 +602,19 @@ class WebChannel(ChatChannel):
         with self._sse_streams_lock:
             state = self.sse_streams.get(request_id)
         if state is None:
+            logger.warning(
+                f"[WebChannel] dropped SSE event for unknown request "
+                f"{request_id}: type={event.get('type')}"
+            )
             return False
 
         with state.condition:
             if state.closed or state.stream_complete:
+                reason = "closed" if state.closed else "complete"
+                logger.warning(
+                    f"[WebChannel] dropped SSE event for {reason} stream "
+                    f"{request_id}: type={event.get('type')}"
+                )
                 return False
             item = dict(event)
             item["seq"] = state.next_seq
@@ -615,6 +638,8 @@ class WebChannel(ChatChannel):
             event_type = item.get("type")
             if event_type == "done":
                 state.main_done = True
+                if state.main_done_at is None:
+                    state.main_done_at = state.last_active
             elif event_type == "stream_end":
                 state.stream_complete = True
                 state.completed_at = state.last_active
@@ -693,11 +718,20 @@ class WebChannel(ChatChannel):
                 # Skip duplicate file pushes here; just let the done event through.
                 if reply.type in (ReplyType.IMAGE_URL, ReplyType.FILE) and content.startswith("file://"):
                     text_content = getattr(reply, 'text_content', '')
-                    if text_content:
+                    with self._sse_streams_lock:
+                        state = self.sse_streams.get(request_id)
+                    already_done = False
+                    if state is not None:
+                        with state.condition:
+                            already_done = state.main_done
+                    # A preceding TEXT reply may already have published done
+                    # and deliberately left the stream open for auto-TTS. In
+                    # that case this duplicate media reply must not end it.
+                    if text_content and not already_done:
                         seqs = self._fetch_latest_pair_seqs(
                             session_id, context.get("agent_id")
                         )
-                        self._publish_sse_event(request_id, {
+                        published = self._publish_sse_event(request_id, {
                             "type": "done",
                             "content": text_content,
                             "request_id": request_id,
@@ -705,7 +739,10 @@ class WebChannel(ChatChannel):
                             "user_seq": seqs.get("user_seq"),
                             "bot_seq": seqs.get("bot_seq"),
                         })
-                    self._publish_sse_event(request_id, {"type": "stream_end"})
+                        if published:
+                            self._publish_sse_event(
+                                request_id, {"type": "stream_end"}
+                            )
                     logger.debug(f"SSE skipped duplicate file for request {request_id}")
                     return
 
@@ -1444,6 +1481,48 @@ class WebChannel(ChatChannel):
                 state.closed = True
                 state.condition.notify_all()
 
+    def _sweep_sse_streams(self, now: Optional[float] = None) -> int:
+        """Finalize overdue tails and reclaim expired SSE replay logs."""
+        now = time.time() if now is None else now
+        with self._sse_streams_lock:
+            states = list(self.sse_streams.items())
+
+        overdue = []
+        for request_id, state in states:
+            with state.condition:
+                if (
+                    state.main_done
+                    and not state.stream_complete
+                    and state.main_done_at is not None
+                    and now - state.main_done_at
+                    >= self.SSE_POST_DONE_TAIL_SECONDS
+                ):
+                    overdue.append(request_id)
+        for request_id in overdue:
+            self._publish_sse_event(request_id, {"type": "stream_end"})
+
+        with self._sse_streams_lock:
+            states = list(self.sse_streams.items())
+        stale = []
+        for request_id, state in states:
+            with state.condition:
+                if state.stream_complete and state.completed_at is not None:
+                    expired = (
+                        now - state.completed_at
+                        >= self.SSE_COMPLETED_TTL_SECONDS
+                    )
+                else:
+                    expired = (
+                        now - state.last_active
+                        >= self.SSE_IDLE_TIMEOUT_SECONDS
+                    )
+            if expired:
+                stale.append(request_id)
+
+        for request_id in stale:
+            self._drop_sse_request(request_id)
+        return len(stale)
+
     def _start_sse_janitor(self):
         """Start a background thread that reclaims orphaned SSE logs.
 
@@ -1454,33 +1533,16 @@ class WebChannel(ChatChannel):
             return
         self._sse_janitor_started = True
 
-        SSE_IDLE_TIMEOUT = 1800  # 30 minutes with no client consumption
         SWEEP_INTERVAL = 60
 
         def _sweep():
             while True:
                 time.sleep(SWEEP_INTERVAL)
                 try:
-                    now = time.time()
-                    with self._sse_streams_lock:
-                        states = list(self.sse_streams.items())
-                    stale = []
-                    for rid, state in states:
-                        with state.condition:
-                            if state.stream_complete and state.completed_at:
-                                expired = (
-                                    now - state.completed_at
-                                    > self.SSE_COMPLETED_TTL_SECONDS
-                                )
-                            else:
-                                expired = now - state.last_active > SSE_IDLE_TIMEOUT
-                        if expired:
-                            stale.append(rid)
-                    for rid in stale:
-                        self._drop_sse_request(rid)
-                    if stale:
+                    reclaimed = self._sweep_sse_streams()
+                    if reclaimed:
                         logger.info(
-                            f"[WebChannel] SSE janitor reclaimed {len(stale)} "
+                            f"[WebChannel] SSE janitor reclaimed {reclaimed} "
                             f"idle stream(s)"
                         )
                 except Exception as e:
@@ -1516,8 +1578,17 @@ class WebChannel(ChatChannel):
         try:
             while time.time() < deadline:
                 resync_payload = None
+                force_stream_end = False
                 with state.condition:
-                    state.last_active = time.time()
+                    now = time.time()
+                    state.last_active = now
+                    force_stream_end = (
+                        state.main_done
+                        and not state.stream_complete
+                        and state.main_done_at is not None
+                        and now - state.main_done_at
+                        >= self.SSE_POST_DONE_TAIL_SECONDS
+                    )
                     if state.events:
                         first_seq = state.events[0][0]["seq"]
                         latest_seq = state.events[-1][0]["seq"]
@@ -1546,6 +1617,12 @@ class WebChannel(ChatChannel):
                         and not pending and not complete and not closed
                     ):
                         state.condition.wait(timeout=1)
+
+                if force_stream_end:
+                    self._publish_sse_event(
+                        request_id, {"type": "stream_end"}
+                    )
+                    continue
 
                 if resync_payload is not None:
                     payload = json.dumps(resync_payload, ensure_ascii=False)
@@ -2264,13 +2341,10 @@ class StreamHandler:
         # Explicit query cursors are used by the frontend's manually-created
         # EventSource. Native EventSource reconnects remain compatible via the
         # standard Last-Event-ID request header.
-        raw_after_seq = params.after_seq
-        if raw_after_seq in (None, ''):
-            raw_after_seq = web.ctx.env.get('HTTP_LAST_EVENT_ID', '0')
-        try:
-            after_seq = max(0, int(raw_after_seq or 0))
-        except (TypeError, ValueError):
-            after_seq = 0
+        after_seq = _parse_sse_cursor(
+            params.after_seq,
+            web.ctx.env.get('HTTP_LAST_EVENT_ID', '0'),
+        )
 
         web.header('Content-Type', 'text/event-stream; charset=utf-8')
         web.header('Cache-Control', 'no-cache')

--- a/tests/test_web_sse_cancel.py
+++ b/tests/test_web_sse_cancel.py
@@ -22,6 +22,7 @@ def _fake_channel():
         request_to_agent={},
         SSE_REPLAY_MAX_EVENTS=5000,
         SSE_REPLAY_MAX_BYTES=4 * 1024 * 1024,
+        SSE_POST_DONE_TAIL_SECONDS=60,
     )
     channel._drop_sse_request = lambda rid: WebChannel._drop_sse_request(channel, rid)
     channel._publish_sse_event = lambda rid, event: WebChannel._publish_sse_event(

--- a/tests/test_web_sse_cancel.py
+++ b/tests/test_web_sse_cancel.py
@@ -1,21 +1,13 @@
-"""SSE teardown after a user cancel.
-
-A cancel only takes effect at the agent's next checkpoint, so the run keeps
-emitting events for a while after Stop is pressed. Closing the stream on a
-blind timer strands in-flight tool bubbles and makes the client reconnect
-onto a reclaimed queue, which surfaces as a bogus "failed to send" bubble.
-"""
+"""SSE teardown after a user cancel."""
 
 import json
 import threading
 import time
-from queue import Queue
 from types import SimpleNamespace
 
 from channel.web import web_channel
 
-# @singleton replaces the class with a factory, so reach the class through the
-# decorator's closure rather than constructing a real channel.
+
 WebChannel = dict(zip(
     web_channel.WebChannel.__code__.co_freevars,
     (cell.cell_contents for cell in web_channel.WebChannel.__closure__),
@@ -23,23 +15,25 @@ WebChannel = dict(zip(
 
 
 def _fake_channel():
-    """Minimal stand-in exposing only what stream_response touches."""
     channel = SimpleNamespace(
-        sse_queues={},
-        sse_last_active={},
+        sse_streams={},
+        _sse_streams_lock=threading.RLock(),
         request_to_session={},
         request_to_agent={},
+        SSE_REPLAY_MAX_EVENTS=5000,
+        SSE_REPLAY_MAX_BYTES=4 * 1024 * 1024,
     )
     channel._drop_sse_request = lambda rid: WebChannel._drop_sse_request(channel, rid)
+    channel._publish_sse_event = lambda rid, event: WebChannel._publish_sse_event(
+        channel, rid, event
+    )
     return channel
 
 
 def _events(chunks):
-    """Parse SSE payloads, skipping keepalive comments."""
     out = []
     for chunk in chunks:
-        text = chunk.decode("utf-8")
-        for line in text.splitlines():
+        for line in chunk.decode("utf-8").splitlines():
             if line.startswith("data: "):
                 out.append(json.loads(line[6:]))
     return out
@@ -48,33 +42,40 @@ def _events(chunks):
 def test_events_after_cancel_still_reach_the_client():
     channel = _fake_channel()
     request_id = "req-1"
-    q = Queue()
-    channel.sse_queues[request_id] = q
-    q.put({"type": "cancelled", "content": "已中止"})
+    channel.sse_streams[request_id] = web_channel.SSEStreamState()
+    channel._publish_sse_event(
+        request_id, {"type": "cancelled", "content": "Cancelled"}
+    )
 
     def late_producer():
-        # Longer than the old 3s post-cancel tail: the tool the agent was
-        # already inside finishes, then the partial reply lands.
         time.sleep(4)
-        q.put({"type": "tool_end", "tool_call_id": "t1", "status": "success"})
-        q.put({"type": "done", "content": "partial answer"})
+        channel._publish_sse_event(request_id, {
+            "type": "tool_end", "tool_call_id": "t1", "status": "success"
+        })
+        channel._publish_sse_event(
+            request_id, {"type": "done", "content": "partial answer"}
+        )
+        channel._publish_sse_event(request_id, {"type": "stream_end"})
 
     threading.Thread(target=late_producer, daemon=True).start()
     events = _events(WebChannel.stream_response(channel, request_id))
 
-    types = [e["type"] for e in events]
-    assert types == ["cancelled", "tool_end", "done"]
-    # Queue reclaimed only once the run actually finished.
-    assert request_id not in channel.sse_queues
+    assert [event["type"] for event in events] == [
+        "cancelled", "tool_end", "done", "stream_end"
+    ]
+    assert request_id in channel.sse_streams
 
 
-def test_unfinished_run_does_not_hold_the_stream_forever():
-    """No trailing "done" (worker died): close instead of leaking the stream."""
+def test_unfinished_run_does_not_hold_closed_client():
     channel = _fake_channel()
     request_id = "req-2"
-    channel.sse_queues[request_id] = Queue()
-    channel.sse_queues[request_id].put({"type": "cancelled", "content": "已中止"})
+    channel.sse_streams[request_id] = web_channel.SSEStreamState()
+    channel._publish_sse_event(
+        request_id, {"type": "cancelled", "content": "Cancelled"}
+    )
 
     generator = WebChannel.stream_response(channel, request_id)
-    assert _events([next(generator)]) == [{"type": "cancelled", "content": "已中止"}]
+    event = _events([next(generator)])[0]
+    assert event["type"] == "cancelled"
+    assert event["seq"] == 1
     generator.close()

--- a/tests/test_web_sse_replay.py
+++ b/tests/test_web_sse_replay.py
@@ -1,7 +1,12 @@
 import json
+import logging
 import threading
+import time
 from types import SimpleNamespace
 
+from bridge.context import Context
+from bridge.reply import Reply, ReplyType
+from agent.memory.conversation_store import ConversationStore
 from channel.web import web_channel
 
 
@@ -19,9 +24,15 @@ def _channel(max_events=5000, max_bytes=4 * 1024 * 1024):
         request_to_agent={},
         SSE_REPLAY_MAX_EVENTS=max_events,
         SSE_REPLAY_MAX_BYTES=max_bytes,
+        SSE_POST_DONE_TAIL_SECONDS=60,
+        SSE_COMPLETED_TTL_SECONDS=60,
+        SSE_IDLE_TIMEOUT_SECONDS=1800,
     )
     channel._publish_sse_event = lambda rid, event: WebChannel._publish_sse_event(
         channel, rid, event
+    )
+    channel._drop_sse_request = lambda rid: WebChannel._drop_sse_request(
+        channel, rid
     )
     return channel
 
@@ -39,6 +50,35 @@ def _events(chunks):
             elif line.startswith("data: "):
                 events.append(json.loads(line[6:]))
     return ids, events
+
+
+def test_explicit_and_native_cursors_use_the_furthest_progress():
+    assert web_channel._parse_sse_cursor("0", "12") == 12
+    assert web_channel._parse_sse_cursor("15", "12") == 15
+    assert web_channel._parse_sse_cursor("invalid", "7") == 7
+
+
+def test_history_exposes_seq_for_merged_assistant_bubble(tmp_path):
+    store = ConversationStore(tmp_path / "history.db")
+    store.append_messages("session", [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": [{
+            "type": "tool_use", "id": "tool-1", "name": "read", "input": {}
+        }]},
+        {"role": "user", "content": [{
+            "type": "tool_result", "tool_use_id": "tool-1", "content": "ok"
+        }]},
+        {"role": "assistant", "content": "answer", "extras": {
+            "audio": {"url": "/uploads/reply.wav"}
+        }},
+    ])
+
+    messages = store.load_history_page("session")["messages"]
+
+    assert [(item["role"], item["_seq"]) for item in messages] == [
+        ("user", 0), ("assistant", 3)
+    ]
+    assert messages[-1]["extras"]["audio"]["url"] == "/uploads/reply.wav"
 
 
 def test_reconnect_replays_only_events_after_cursor():
@@ -104,6 +144,47 @@ def test_requests_have_independent_sequences_and_logs():
     assert a_events[0]["seq"] == b_events[0]["seq"] == 1
 
 
+def test_concurrent_readers_each_receive_the_complete_log():
+    channel = _channel()
+    _add_stream(channel, "req")
+    channel._publish_sse_event("req", {"type": "delta", "content": "a"})
+
+    readers_ready = threading.Barrier(3)
+    results = [None, None]
+
+    def read_stream(index):
+        chunks = []
+        stream = WebChannel.stream_response(channel, "req")
+        chunks.append(next(stream))
+        readers_ready.wait()
+        chunks.extend(stream)
+        results[index] = _events(chunks)
+
+    readers = [
+        threading.Thread(target=read_stream, args=(index,))
+        for index in range(2)
+    ]
+    for reader in readers:
+        reader.start()
+    readers_ready.wait(timeout=2)
+
+    channel._publish_sse_event("req", {"type": "delta", "content": "b"})
+    channel._publish_sse_event("req", {"type": "done", "content": "ab"})
+    channel._publish_sse_event("req", {"type": "stream_end"})
+
+    for reader in readers:
+        reader.join(timeout=2)
+        assert not reader.is_alive()
+
+    first_ids, first_events = results[0]
+    second_ids, second_events = results[1]
+    assert first_ids == second_ids == [1, 2, 3, 4]
+    assert [item["type"] for item in first_events] == [
+        "delta", "delta", "done", "stream_end"
+    ]
+    assert first_events == second_events
+
+
 def test_expired_cursor_requires_resync_when_count_limit_evicts_events():
     channel = _channel(max_events=2)
     _add_stream(channel, "req")
@@ -130,3 +211,99 @@ def test_byte_limit_also_evicts_old_events():
     state = channel.sse_streams["req"]
     assert len(state.events) == 1
     assert state.events[0][0]["seq"] == 4
+
+
+def test_late_event_drop_is_visible_in_logs(caplog):
+    channel = _channel()
+    _add_stream(channel, "req")
+    channel._publish_sse_event("req", {"type": "stream_end"})
+
+    with caplog.at_level(logging.WARNING):
+        published = channel._publish_sse_event(
+            "req", {"type": "voice_attach", "url": "/audio.mp3"}
+        )
+
+    assert not published
+    assert "dropped SSE event for complete stream req" in caplog.text
+
+
+def test_overdue_done_is_bounded_by_stream_end():
+    channel = _channel()
+    _add_stream(channel, "req")
+    channel._publish_sse_event("req", {"type": "done", "content": "answer"})
+    state = channel.sse_streams["req"]
+    state.main_done_at = time.time() - 61
+
+    _, events = _events(WebChannel.stream_response(channel, "req"))
+
+    assert [item["type"] for item in events] == ["done", "stream_end"]
+    assert state.stream_complete
+
+
+def test_janitor_finalizes_done_then_reclaims_completed_log():
+    channel = _channel()
+    _add_stream(channel, "req")
+    channel._publish_sse_event("req", {"type": "done", "content": "answer"})
+    state = channel.sse_streams["req"]
+    now = time.time()
+    state.main_done_at = now - 61
+
+    assert WebChannel._sweep_sse_streams(channel, now) == 0
+    assert state.stream_complete
+
+    state.completed_at = now - 61
+    assert WebChannel._sweep_sse_streams(channel, now) == 1
+    assert "req" not in channel.sse_streams
+
+
+def _send_channel(tts_pending=False):
+    channel = _channel()
+    channel.NOT_SUPPORT_REPLYTYPE = []
+    channel.session_queues = {}
+    channel.request_to_session["req"] = "session"
+    channel.request_to_agent["req"] = "agent"
+    channel._session_queue_key = lambda session_id, agent_id=None: session_id
+    channel._fetch_latest_pair_seqs = lambda *args: {
+        "user_seq": 1, "bot_seq": 2
+    }
+    channel._maybe_dispatch_auto_tts = lambda *args: tts_pending
+    _add_stream(channel, "req")
+    context = Context(kwargs={
+        "request_id": "req", "agent_id": "agent", "session_id": "session"
+    })
+    return channel, context
+
+
+def test_duplicate_file_does_not_close_text_stream_waiting_for_tts():
+    channel, context = _send_channel(tts_pending=True)
+    WebChannel.send(channel, Reply(ReplyType.TEXT, "answer"), context)
+    state = channel.sse_streams["req"]
+    assert state.main_done
+    assert not state.stream_complete
+
+    WebChannel.send(channel, Reply(ReplyType.FILE, "file://result.txt"), context)
+
+    assert not state.stream_complete
+    assert [item[0]["type"] for item in state.events] == ["done"]
+
+
+def test_duplicate_file_without_text_does_not_end_an_unfinished_stream():
+    channel, context = _send_channel()
+
+    WebChannel.send(channel, Reply(ReplyType.FILE, "file://result.txt"), context)
+
+    state = channel.sse_streams["req"]
+    assert not state.main_done
+    assert not state.stream_complete
+    assert list(state.events) == []
+
+
+def test_file_with_own_text_publishes_done_before_stream_end():
+    channel, context = _send_channel()
+    reply = Reply(ReplyType.FILE, "file://result.txt")
+    reply.text_content = "answer with file"
+
+    WebChannel.send(channel, reply, context)
+
+    state = channel.sse_streams["req"]
+    assert [item[0]["type"] for item in state.events] == ["done", "stream_end"]

--- a/tests/test_web_sse_replay.py
+++ b/tests/test_web_sse_replay.py
@@ -1,0 +1,132 @@
+import json
+import threading
+from types import SimpleNamespace
+
+from channel.web import web_channel
+
+
+WebChannel = dict(zip(
+    web_channel.WebChannel.__code__.co_freevars,
+    (cell.cell_contents for cell in web_channel.WebChannel.__closure__),
+))["cls"]
+
+
+def _channel(max_events=5000, max_bytes=4 * 1024 * 1024):
+    channel = SimpleNamespace(
+        sse_streams={},
+        _sse_streams_lock=threading.RLock(),
+        request_to_session={},
+        request_to_agent={},
+        SSE_REPLAY_MAX_EVENTS=max_events,
+        SSE_REPLAY_MAX_BYTES=max_bytes,
+    )
+    channel._publish_sse_event = lambda rid, event: WebChannel._publish_sse_event(
+        channel, rid, event
+    )
+    return channel
+
+
+def _add_stream(channel, request_id):
+    channel.sse_streams[request_id] = web_channel.SSEStreamState()
+
+
+def _events(chunks):
+    events, ids = [], []
+    for chunk in chunks:
+        for line in chunk.decode("utf-8").splitlines():
+            if line.startswith("id: "):
+                ids.append(int(line[4:]))
+            elif line.startswith("data: "):
+                events.append(json.loads(line[6:]))
+    return ids, events
+
+
+def test_reconnect_replays_only_events_after_cursor():
+    channel = _channel()
+    _add_stream(channel, "req")
+    for content in ("a", "b", "c"):
+        channel._publish_sse_event("req", {"type": "delta", "content": content})
+    channel._publish_sse_event("req", {"type": "done", "content": "abc"})
+    channel._publish_sse_event("req", {"type": "stream_end"})
+
+    ids, events = _events(WebChannel.stream_response(channel, "req", after_seq=2))
+
+    assert ids == [3, 4, 5]
+    assert [event["seq"] for event in events] == [3, 4, 5]
+    assert [event["type"] for event in events] == ["delta", "done", "stream_end"]
+
+
+def test_delivery_interruption_does_not_remove_event_from_log():
+    channel = _channel()
+    _add_stream(channel, "req")
+    channel._publish_sse_event("req", {"type": "delta", "content": "first"})
+    channel._publish_sse_event("req", {"type": "delta", "content": "second"})
+
+    first_connection = WebChannel.stream_response(channel, "req")
+    ids, _ = _events([next(first_connection)])
+    assert ids == [1]
+    first_connection.close()
+
+    channel._publish_sse_event("req", {"type": "done", "content": "firstsecond"})
+    channel._publish_sse_event("req", {"type": "stream_end"})
+    ids, events = _events(WebChannel.stream_response(channel, "req", after_seq=0))
+
+    assert ids == [1, 2, 3, 4]
+    assert [event["seq"] for event in events] == [1, 2, 3, 4]
+
+
+def test_done_and_voice_attachment_are_replayable_until_stream_end():
+    channel = _channel()
+    _add_stream(channel, "req")
+    channel._publish_sse_event("req", {"type": "done", "content": "answer"})
+    channel._publish_sse_event("req", {"type": "voice_attach", "url": "/audio.mp3"})
+    channel._publish_sse_event("req", {"type": "stream_end"})
+
+    _, events = _events(WebChannel.stream_response(channel, "req", after_seq=1))
+
+    assert [event["type"] for event in events] == ["voice_attach", "stream_end"]
+
+
+def test_requests_have_independent_sequences_and_logs():
+    channel = _channel()
+    _add_stream(channel, "a")
+    _add_stream(channel, "b")
+    channel._publish_sse_event("a", {"type": "delta", "content": "A"})
+    channel._publish_sse_event("b", {"type": "delta", "content": "B"})
+    channel._publish_sse_event("a", {"type": "stream_end"})
+    channel._publish_sse_event("b", {"type": "stream_end"})
+
+    _, a_events = _events(WebChannel.stream_response(channel, "a"))
+    _, b_events = _events(WebChannel.stream_response(channel, "b"))
+
+    assert [event.get("content") for event in a_events if "content" in event] == ["A"]
+    assert [event.get("content") for event in b_events if "content" in event] == ["B"]
+    assert a_events[0]["seq"] == b_events[0]["seq"] == 1
+
+
+def test_expired_cursor_requires_resync_when_count_limit_evicts_events():
+    channel = _channel(max_events=2)
+    _add_stream(channel, "req")
+    for content in ("a", "b", "c"):
+        channel._publish_sse_event("req", {"type": "delta", "content": content})
+
+    ids, events = _events(WebChannel.stream_response(channel, "req", after_seq=0))
+
+    assert ids == []
+    assert events == [{
+        "type": "resync_required",
+        "reason": "event_cursor_expired",
+        "after_seq": 0,
+        "first_available_seq": 2,
+    }]
+
+
+def test_byte_limit_also_evicts_old_events():
+    channel = _channel(max_events=100, max_bytes=160)
+    _add_stream(channel, "req")
+    for _ in range(4):
+        channel._publish_sse_event("req", {"type": "delta", "content": "x" * 80})
+
+    state = channel.sse_streams["req"]
+    assert len(state.events) == 1
+    assert state.events[0][0]["seq"] == 4


### PR DESCRIPTION
## What does this PR do?

The Web SSE endpoint currently consumes events destructively from a shared
in-memory queue. If a connection drops after an event is removed from the
queue but before the browser receives it, reconnecting with the same request
ID cannot recover that event.

Concurrent or briefly overlapping connections can also compete for the same
queue and receive different parts of the stream.

This PR adds reliable SSE reconnection within a single CowAgent process:

- Assigns a monotonically increasing sequence number to every SSE event.
- Emits the sequence through both the SSE `id` field and JSON `seq`.
- Replaces destructive queue consumption with a bounded per-request event log.
- Gives every connection an independent read cursor.
- Supports both the `after_seq` query parameter and `Last-Event-ID` header.
- Replays events newer than the client cursor after reconnection.
- Deduplicates replayed events on the frontend.
- Reports `resync_required` when the requested cursor has expired.
- Retains completed streams for a short replay grace period.
- Separates main-answer completion (`done`) from full stream completion
  (`stream_end`), allowing asynchronous events such as `voice_attach` to
  arrive after the answer.

Replay logs are bounded by both event count and serialized byte size.

This PR intentionally does not add Redis persistence, multi-process
coordination, process-restart recovery, delta merging, or rendering
refactoring.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Testing

- 8 SSE replay and cancellation tests passed.
- 26 Web/SSE-related regression tests passed.
- Python compilation check passed.
- JavaScript syntax check passed.
- Manual browser verification passed:
  - sequence IDs are emitted correctly;
  - reconnection includes `after_seq`;
  - replayed events are deduplicated;
  - concurrent SSE connections no longer compete for events;
  - final answers and stream lifecycle events remain complete.

The full Windows test suite was also executed; no failures occurred in the SSE or related Web tests.

## Checklist

- [x] I have read the Contributing Guide
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): N/A