### PR TITLE
feat: make LLM API max retries configurable (llm_max_retries)

### DIFF
--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -1078,20 +1078,28 @@ class AgentStreamExecutor:
             logger.debug(f"[ToolRetrieval] full injection (retrieval skipped): {e}")
             return all_tools
 
-    def _call_llm_stream(self, retry_on_empty=True, retry_count=0, max_retries=3,
+    def _call_llm_stream(self, retry_on_empty=True, retry_count=0, max_retries=None,
                          _overflow_retry: bool = False) -> Tuple[str, List[Dict]]:
         """
         Call LLM with streaming and automatic retry on errors
-        
+
         Args:
             retry_on_empty: Whether to retry once if empty response is received
             retry_count: Current retry attempt (internal use)
-            max_retries: Maximum number of retries for API errors
+            max_retries: Maximum number of retries for API errors. When None,
+                falls back to the "llm_max_retries" config value (default 3)
             _overflow_retry: Internal flag indicating this is a retry after context overflow
-        
+
         Returns:
             (response_text, tool_calls)
         """
+        if max_retries is None:
+            from config import conf
+            raw = conf().get("llm_max_retries")
+            try:
+                max_retries = max(0, int(raw)) if raw is not None else 3
+            except (TypeError, ValueError):
+                max_retries = 3
         # Validate and fix message history (e.g. orphaned tool_result blocks).
         # Context trimming is done once in run_stream() before the loop starts,
         # NOT here — trimming mid-execution would strip the current run's

--- a/config-template.json
+++ b/config-template.json
@@ -38,6 +38,7 @@
   "agent_max_context_tokens": 64000,
   "agent_max_context_turns": 30,
   "agent_max_steps": 30,
+  "llm_max_retries": 3,
   "subagent": {
     "enabled": true,
     "max_concurrent": 3

--- a/docs/guide/manual-install.mdx
+++ b/docs/guide/manual-install.mdx
@@ -141,6 +141,7 @@ sudo docker logs -f chatgpt-on-wechat
 | `agent_max_context_tokens` | Max context tokens | `40000` |
 | `agent_max_context_turns` | Max context turns | `30` |
 | `agent_max_steps` | Max decision steps per task | `15` |
+| `llm_max_retries` | Max retries for LLM API errors | `3` |
 | `cow_lang` | Language for the UI, command text and system prompts; `auto` to detect, or set `zh` / `en` | `auto` |
 
 <Tip>

--- a/docs/intro/architecture.mdx
+++ b/docs/intro/architecture.mdx
@@ -83,6 +83,7 @@ Configure Agent mode parameters in `config.json`:
 | `agent_max_context_tokens` | Max context tokens | `50000` |
 | `agent_max_context_turns` | Max context turns | `20` |
 | `agent_max_steps` | Max decision steps per task | `20` |
+| `llm_max_retries` | Max retries for LLM API errors | `3` |
 | `enable_thinking` | Enable deep-thinking mode | `false` |
 | `knowledge` | Enable personal knowledge base | `true` |
 | `self_evolution_enabled` | Enable Self-Evolution (on by default for new installs) | `false` |

--- a/docs/memory/context.mdx
+++ b/docs/memory/context.mdx
@@ -22,6 +22,7 @@ A single turn may include multiple tool calls (controlled by `agent_max_steps`).
 | `agent_max_context_tokens` | Maximum context token budget | `64000` |
 | `agent_max_context_turns` | Maximum conversation turns in context | `30` |
 | `agent_max_steps` | Maximum decision steps per turn (tool call count) | `30` |
+| `llm_max_retries` | Maximum retries for LLM API errors | `3` |
 
 Configurable via `config.json` or the `/config` chat command.
 


### PR DESCRIPTION
## What

The retry count for LLM API errors was hardcoded to `3` in `_call_llm_stream`. This adds an `llm_max_retries` config key so it can be tuned without patching code.

## Why

On unstable networks (flaky mobile hotspots, transient proxy failures), the default backoff window — `2s / 4s / 6s`, ~12s total — often gives up **before connectivity recovers**, leaving the whole turn dead even though the API itself is fine. Letting users raise the limit (e.g. to `10`, ~110s window with the existing incremental backoff) makes the agent survive real-world network hiccups.

## Changes

- `agent/protocol/agent_stream.py` — `_call_llm_stream(max_retries=None)`; when `None`, resolve from `conf().get("llm_max_retries")` with default `3`. Recursive retries pass the resolved value explicitly, so existing semantics are unchanged. Invalid values fall back to `3`; negatives clamp to `0`.
- `config-template.json` — new `"llm_max_retries": 3` (default preserves current behavior).
- Docs — added the parameter to the config tables in `architecture.mdx`, `manual-install.mdx`, `context.mdx`.

## Compatibility

Fully backward-compatible: no config key → default `3` (current behavior). All existing call sites use keyword args.

## Testing

- `python -m py_compile` passes.
- Resolution logic unit-tested across 7 cases: unset→3, `10`→10, `0`→0, `-5`→0, `"abc"`→3, `null`→3, `"7"`→7. All pass.
