### PR TITLE
fix: accept end-of-day service stop time

### DIFF
--- a/common/time_check.py
+++ b/common/time_check.py
@@ -13,15 +13,24 @@ def time_checker(f):
             chat_start_time = _config.get("chat_start_time", "00:00")
             chat_stop_time = _config.get("chat_stop_time", "24:00")
 
-            time_regex = re.compile(r"^([01]?[0-9]|2[0-4])(:)([0-5][0-9])$")
+            time_regex = re.compile(r"^([01]?[0-9]|2[0-3]):[0-5][0-9]$")
 
-            if not (time_regex.match(chat_start_time) and time_regex.match(chat_stop_time)):
+            if not (
+                time_regex.match(chat_start_time)
+                and (time_regex.match(chat_stop_time) or chat_stop_time == "24:00")
+            ):
                 logger.warning("时间格式不正确，请在config.json中修改CHAT_START_TIME/CHAT_STOP_TIME。")
                 return None
 
-            now_time = time.strptime(time.strftime("%H:%M"), "%H:%M")
-            chat_start_time = time.strptime(chat_start_time, "%H:%M")
-            chat_stop_time = time.strptime(chat_stop_time, "%H:%M")
+            def _to_minutes(value):
+                hours, minutes = (int(part) for part in value.split(":"))
+                return hours * 60 + minutes
+
+            now_time = _to_minutes(time.strftime("%H:%M"))
+            chat_start_time = _to_minutes(chat_start_time)
+            chat_stop_time = (
+                24 * 60 if chat_stop_time == "24:00" else _to_minutes(chat_stop_time)
+            )
             # 结束时间小于开始时间，跨天了
             if chat_stop_time < chat_start_time and (chat_start_time <= now_time or now_time <= chat_stop_time):
                 f(self, *args, **kwargs)

--- a/tests/test_time_check.py
+++ b/tests/test_time_check.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+
+from common.time_check import time_checker
+
+
+class TimeCheckerTest(unittest.TestCase):
+    @staticmethod
+    def _handler(calls):
+        @time_checker
+        def handler(_self):
+            calls.append("handled")
+
+        return handler
+
+    def test_default_end_of_day_stop_time_allows_messages(self):
+        calls = []
+        handler = self._handler(calls)
+
+        with patch(
+            "common.time_check.config.conf",
+            return_value={"chat_time_module": True},
+        ):
+            handler(object())
+
+        self.assertEqual(calls, ["handled"])
+
+    def test_invalid_24th_hour_stop_time_is_rejected_without_crashing(self):
+        calls = []
+        handler = self._handler(calls)
+
+        with patch(
+            "common.time_check.config.conf",
+            return_value={
+                "chat_time_module": True,
+                "chat_start_time": "00:00",
+                "chat_stop_time": "24:01",
+            },
+        ):
+            handler(object())
+
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

The default service-time configuration uses `chat_stop_time = "24:00"`, but
the current validator passes that value to `time.strptime(..., "%H:%M")`.
Python only accepts hours from 00 through 23 for `%H`, so enabling the time
module with its default values raises `ValueError` before a decorated message
handler can run.

This change:

- accepts `24:00` only as the end-of-day stop-time sentinel;
- converts validated clock values to integer minutes for comparisons; and
- rejects values such as `24:01` through the existing warning path instead of
  raising an exception.

The existing same-day and cross-midnight comparison behavior is preserved.

### Regression evidence

- Before the fix, both new tests failed with `ValueError` for `24:00` and
  `24:01`.
- After the fix, `python3 -m unittest discover -s tests -p 'test_time_check.py' -v`
  passes 2 tests.
- `python -m pytest -q tests/test_time_check.py tests/test_channel_double_start.py`
  passes 5 tests.
- Python compilation and `git diff --check` pass.

The repository-wide test suite is not clean on the tested base: the exact base
and this branch both report the same 41 unrelated failures. This branch changes
the passing count from 732 to 734 by adding the two regression tests and adds no
new full-suite failure.

Scope: 2 files, +60 / -5 lines, with no dependency changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): none; no equivalent issue or pull request was found
