### PR TITLE
feat(memory): add pluggable vector backend

### DIFF
--- a/agent/memory/__init__.py
+++ b/agent/memory/__init__.py
@@ -5,7 +5,6 @@ Provides both long-term memory (vector/keyword search) and short-term
 conversation history persistence (SQLite).
 """
 
-from agent.memory.manager import MemoryManager
 from agent.memory.config import (
     MemoryConfig,
     get_default_memory_config,
@@ -13,13 +12,23 @@ from agent.memory.config import (
     reset_memory_configs,
     set_global_memory_config,
 )
-from agent.memory.embedding import create_embedding_provider, create_default_embedding_provider
 from agent.memory.conversation_store import (
     ConversationStore,
     clear_conversation_store_cache,
     get_conversation_store,
 )
+from agent.memory.embedding import (
+    create_default_embedding_provider,
+    create_embedding_provider,
+)
+from agent.memory.manager import MemoryManager
 from agent.memory.summarizer import ensure_daily_memory_file
+from agent.memory.vector_backend import (
+    SQLiteVectorBackend,
+    VectorBackend,
+    VectorMatch,
+    VectorRecord,
+)
 
 __all__ = [
     'MemoryManager',
@@ -30,6 +39,10 @@ __all__ = [
     'set_global_memory_config',
     'create_embedding_provider',
     'create_default_embedding_provider',
+    'VectorBackend',
+    'SQLiteVectorBackend',
+    'VectorRecord',
+    'VectorMatch',
     'ConversationStore',
     'clear_conversation_store_cache',
     'get_conversation_store',

--- a/agent/memory/storage.py
+++ b/agent/memory/storage.py
@@ -5,16 +5,24 @@ Provides vector and keyword search capabilities
 """
 
 from __future__ import annotations
+
+import hashlib
+import json
 import os
 import re
 import sqlite3
-import json
-import hashlib
 import threading
 import time
-from typing import List, Dict, Optional, Any
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory.vector_backend import (
+    SQLiteVectorBackend,
+    VectorBackend,
+    VectorRecord,
+)
+
 try:
     import numpy as np
     _HAS_NUMPY = True
@@ -103,15 +111,23 @@ class SearchResult:
 class MemoryStorage:
     """SQLite-based storage with FTS5 for keyword search"""
     
-    def __init__(self, db_path: Path):
+    def __init__(
+        self,
+        db_path: Path,
+        vector_backend: Optional[VectorBackend] = None,
+    ):
         self.db_path = db_path
         self.conn: Optional[sqlite3.Connection] = None
+        self.vector_backend = vector_backend
         self.fts5_available = False  # Track FTS5 availability
         # RLock protects concurrent writes from the same process.
         # SQLite WAL mode handles read/write concurrency at the file level,
         # but same-process concurrent writes still need a Python-level lock.
         self._lock = threading.RLock()
         self._init_db()
+        if self.vector_backend is None:
+            assert self.conn is not None
+            self.vector_backend = SQLiteVectorBackend(self.conn)
     
     def _check_fts5_support(self) -> bool:
         """Check if SQLite has FTS5 support"""
@@ -551,13 +567,18 @@ class MemoryStorage:
         params = (
             chunk.id, chunk.user_id, chunk.scope, chunk.source, chunk.path,
             chunk.start_line, chunk.end_line, chunk.text,
-            self._encode_embedding(chunk.embedding),
+            None,
             chunk.hash,
             json.dumps(chunk.metadata) if chunk.metadata else None,
         )
         with self._lock:
-            self.conn.execute(_SQL, params)
-            self.conn.commit()
+            try:
+                self.conn.execute(_SQL, params)
+                self.vector_backend.upsert([self._to_vector_record(chunk)])
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     def save_chunks_batch(self, chunks: List[MemoryChunk]):
         """Save multiple chunks in a batch (insert or update by id).
@@ -594,15 +615,22 @@ class MemoryStorage:
             (
                 c.id, c.user_id, c.scope, c.source, c.path,
                 c.start_line, c.end_line, c.text,
-                self._encode_embedding(c.embedding),
+                None,
                 c.hash,
                 json.dumps(c.metadata) if c.metadata else None,
             )
             for c in chunks
         ]
         with self._lock:
-            self.conn.executemany(_SQL, params_list)
-            self.conn.commit()
+            try:
+                self.conn.executemany(_SQL, params_list)
+                self.vector_backend.upsert([
+                    self._to_vector_record(chunk) for chunk in chunks
+                ])
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
     
     def get_chunk(self, chunk_id: str) -> Optional[MemoryChunk]:
         """Get a chunk by ID"""
@@ -622,118 +650,31 @@ class MemoryStorage:
         scopes: List[str] = None,
         limit: int = 10
     ) -> List[SearchResult]:
-        """
-        Vector similarity search using numpy-vectorized cosine similarity.
-        All embeddings are loaded then scored in a single BLAS matrix-vector
-        multiply, which is ~100x faster than the pure-Python per-row loop.
-        """
+        """Search the configured vector backend."""
         if scopes is None:
             scopes = ["shared"]
             if user_id:
                 scopes.append("user")
-
-        scope_placeholders = ','.join('?' * len(scopes))
-        params = list(scopes)
-
+        metadata_filter = {"scopes": scopes}
         if user_id:
-            query = f"""
-                SELECT * FROM chunks
-                WHERE scope IN ({scope_placeholders})
-                AND (scope = 'shared' OR user_id = ?)
-                AND embedding IS NOT NULL
-            """
-            params.append(user_id)
-        else:
-            query = f"""
-                SELECT * FROM chunks
-                WHERE scope IN ({scope_placeholders})
-                AND embedding IS NOT NULL
-            """
-
-        rows = self.conn.execute(query, params).fetchall()
-        if not rows:
-            return []
-
-        # Parse embeddings and build a (N, D) matrix in one pass.
-        # New rows store BLOB bytes (np.frombuffer); legacy rows fall back to JSON.
-        # Filter out rows whose embedding dimension differs from the query —
-        # mixing dimensions would cause np.array() to produce an object array
-        # and matrix @ q_vec to raise ValueError.
-        expected_dim = len(query_embedding)
-        valid_rows = []
-        vectors = []
-        for row in rows:
-            vec = self._decode_embedding(row['embedding'])
-            if not vec:
-                continue
-            if len(vec) != expected_dim:
-                from common.log import logger
-                logger.warning(
-                    "[MemoryStorage] Skipping chunk %s: embedding dim %d != query dim %d",
-                    row['id'], len(vec), expected_dim
-                )
-                continue
-            valid_rows.append(row)
-            vectors.append(vec)
-
-        if not vectors:
-            return []
-
-        if _HAS_NUMPY:
-            matrix = np.array(vectors, dtype=np.float32)        # (N, D)
-            q_vec = np.array(query_embedding, dtype=np.float32)  # (D,)
-
-            # Vectorized cosine similarity: dot(matrix, q) / (||matrix|| * ||q||)
-            dots = matrix @ q_vec                                # (N,)
-            row_norms = np.linalg.norm(matrix, axis=1)           # (N,)
-            q_norm = float(np.linalg.norm(q_vec))
-            denominators = row_norms * q_norm
-            np.maximum(denominators, 1e-10, out=denominators)    # avoid div-by-zero
-            sims = dots / denominators                           # (N,)
-
-            # Select TopK using argpartition (O(N) average), then sort only those K
-            k = min(limit, len(valid_rows))
-            top_idx = np.argpartition(sims, -k)[-k:]
-            top_idx = top_idx[np.argsort(sims[top_idx])[::-1]]
-
-            return [
-                SearchResult(
-                    path=valid_rows[i]['path'],
-                    start_line=valid_rows[i]['start_line'],
-                    end_line=valid_rows[i]['end_line'],
-                    score=float(sims[i]),
-                    snippet=self._truncate_text(valid_rows[i]['text'], 500),
-                    source=valid_rows[i]['source'],
-                    user_id=valid_rows[i]['user_id']
-                )
-                for i in top_idx
-                if sims[i] > 0
-            ]
-        else:
-            # Pure-Python cosine similarity fallback (numpy not installed)
-            import math
-            q = query_embedding
-            q_norm = math.sqrt(sum(x * x for x in q)) or 1e-10
-            scored = []
-            for i, vec in enumerate(vectors):
-                dot = sum(a * b for a, b in zip(vec, q))
-                v_norm = math.sqrt(sum(x * x for x in vec)) or 1e-10
-                sim = dot / (v_norm * q_norm)
-                if sim > 0:
-                    scored.append((sim, valid_rows[i]))
-            scored.sort(key=lambda x: x[0], reverse=True)
-            return [
-                SearchResult(
-                    path=row['path'],
-                    start_line=row['start_line'],
-                    end_line=row['end_line'],
-                    score=sim,
-                    snippet=self._truncate_text(row['text'], 500),
-                    source=row['source'],
-                    user_id=row['user_id']
-                )
-                for sim, row in scored[:limit]
-            ]
+            metadata_filter["user_id"] = user_id
+        matches = self.vector_backend.search(
+            query_embedding,
+            limit=limit,
+            metadata_filter=metadata_filter,
+        )
+        return [
+            SearchResult(
+                path=match.metadata["path"],
+                start_line=match.metadata["start_line"],
+                end_line=match.metadata["end_line"],
+                score=match.score,
+                snippet=self._truncate_text(match.metadata["text"], 500),
+                source=match.metadata["source"],
+                user_id=match.metadata.get("user_id"),
+            )
+            for match in matches
+        ]
     
     def search_keyword(
         self,
@@ -928,9 +869,14 @@ class MemoryStorage:
     def delete_by_path(self, path: str):
         """Delete all chunks and file metadata for a path."""
         with self._lock:
-            self.conn.execute("DELETE FROM chunks WHERE path = ?", (path,))
-            self.conn.execute("DELETE FROM files WHERE path = ?", (path,))
-            self.conn.commit()
+            try:
+                self.vector_backend.delete(metadata_filter={"path": path})
+                self.conn.execute("DELETE FROM chunks WHERE path = ?", (path,))
+                self.conn.execute("DELETE FROM files WHERE path = ?", (path,))
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     def get_file_hash(self, path: str) -> Optional[str]:
         """Get stored file hash"""
@@ -989,15 +935,21 @@ class MemoryStorage:
     # Helper methods
 
     @staticmethod
-    def _encode_embedding(embedding: Optional[List[float]]) -> Optional[bytes]:
-        """Encode embedding as float32 BLOB bytes (~6x smaller and faster than JSON).
-        Falls back to struct.pack when numpy is unavailable."""
-        if embedding is None:
-            return None
-        if _HAS_NUMPY:
-            return np.array(embedding, dtype=np.float32).tobytes()
-        import struct
-        return struct.pack(f'{len(embedding)}f', *embedding)
+    def _to_vector_record(chunk: MemoryChunk) -> VectorRecord:
+        return VectorRecord(
+            id=chunk.id,
+            embedding=chunk.embedding,
+            metadata={
+                "user_id": chunk.user_id,
+                "scope": chunk.scope,
+                "source": chunk.source,
+                "path": chunk.path,
+                "start_line": chunk.start_line,
+                "end_line": chunk.end_line,
+                "text": chunk.text,
+                "metadata": chunk.metadata,
+            },
+        )
 
     @staticmethod
     def _decode_embedding(raw) -> Optional[List[float]]:

--- a/agent/memory/vector_backend.py
+++ b/agent/memory/vector_backend.py
@@ -1,0 +1,246 @@
+"""Pluggable vector storage contract for memory retrieval."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+import struct
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+try:
+    import numpy as np
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+    np = None  # type: ignore[assignment]
+
+
+@dataclass
+class VectorRecord:
+    """A vector and the metadata needed to reconstruct a memory result."""
+
+    id: str
+    embedding: Optional[List[float]]
+    metadata: Dict[str, Any]
+
+
+@dataclass
+class VectorMatch:
+    """A scored vector match returned by a backend."""
+
+    id: str
+    score: float
+    metadata: Dict[str, Any]
+
+
+class VectorBackend(ABC):
+    """Storage-independent vector operations used by memory."""
+
+    @abstractmethod
+    def upsert(self, records: Sequence[VectorRecord]) -> None:
+        """Insert or update vector records."""
+
+    @abstractmethod
+    def delete(
+        self,
+        ids: Optional[Sequence[str]] = None,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Delete vectors by IDs and/or metadata."""
+
+    @abstractmethod
+    def search(
+        self,
+        query_embedding: Sequence[float],
+        limit: int = 10,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorMatch]:
+        """Return the highest-scoring matches satisfying the filter."""
+
+
+class SQLiteVectorBackend(VectorBackend):
+    """Vector backend backed by the existing ``chunks.embedding`` column.
+
+    The owning ``MemoryStorage`` controls locking and transaction boundaries,
+    so writes intentionally do not commit here.
+    """
+
+    _FILTER_COLUMNS = {"id", "user_id", "scope", "source", "path"}
+
+    def __init__(self, connection: sqlite3.Connection):
+        self.connection = connection
+
+    def upsert(self, records: Sequence[VectorRecord]) -> None:
+        self.connection.executemany(
+            "UPDATE chunks SET embedding = ? WHERE id = ?",
+            [
+                (self._encode_embedding(record.embedding), record.id)
+                for record in records
+            ],
+        )
+
+    def delete(
+        self,
+        ids: Optional[Sequence[str]] = None,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        clauses, params = self._build_filter(metadata_filter)
+        if ids is not None:
+            if not ids:
+                return
+            clauses.append("id IN ({})".format(",".join("?" for _ in ids)))
+            params.extend(ids)
+        if not clauses:
+            raise ValueError("Vector deletion requires IDs or a metadata filter")
+        self.connection.execute(
+            "UPDATE chunks SET embedding = NULL WHERE " + " AND ".join(clauses),
+            params,
+        )
+
+    def search(
+        self,
+        query_embedding: Sequence[float],
+        limit: int = 10,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorMatch]:
+        if limit <= 0 or not query_embedding:
+            return []
+
+        clauses, params = self._build_filter(
+            metadata_filter,
+            shared_visible_to_user=True,
+        )
+        clauses.append("embedding IS NOT NULL")
+        rows = self.connection.execute(
+            "SELECT * FROM chunks WHERE " + " AND ".join(clauses),
+            params,
+        ).fetchall()
+        if not rows:
+            return []
+
+        expected_dim = len(query_embedding)
+        valid_rows = []
+        vectors = []
+        for row in rows:
+            vector = self._decode_embedding(row["embedding"])
+            if not vector:
+                continue
+            if len(vector) != expected_dim:
+                from common.log import logger
+
+                logger.warning(
+                    "[SQLiteVectorBackend] Skipping chunk %s: "
+                    "embedding dim %d != query dim %d",
+                    row["id"],
+                    len(vector),
+                    expected_dim,
+                )
+                continue
+            valid_rows.append(row)
+            vectors.append(vector)
+
+        if not vectors:
+            return []
+
+        if _HAS_NUMPY:
+            scores = self._numpy_scores(vectors, query_embedding)
+            count = min(limit, len(valid_rows))
+            top_indices = np.argpartition(scores, -count)[-count:]
+            top_indices = top_indices[np.argsort(scores[top_indices])[::-1]]
+            return [
+                self._match(valid_rows[index], float(scores[index]))
+                for index in top_indices
+                if scores[index] > 0
+            ]
+
+        query_norm = math.sqrt(sum(value * value for value in query_embedding)) or 1e-10
+        scored = []
+        for row, vector in zip(valid_rows, vectors):
+            dot = sum(left * right for left, right in zip(vector, query_embedding))
+            vector_norm = math.sqrt(sum(value * value for value in vector)) or 1e-10
+            score = dot / (vector_norm * query_norm)
+            if score > 0:
+                scored.append((score, row))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [self._match(row, score) for score, row in scored[:limit]]
+
+    @staticmethod
+    def _numpy_scores(vectors, query_embedding):
+        matrix = np.array(vectors, dtype=np.float32)
+        query = np.array(query_embedding, dtype=np.float32)
+        dots = matrix @ query
+        denominators = np.linalg.norm(matrix, axis=1) * float(np.linalg.norm(query))
+        np.maximum(denominators, 1e-10, out=denominators)
+        return dots / denominators
+
+    @classmethod
+    def _build_filter(cls, metadata_filter, shared_visible_to_user=False):
+        clauses = []
+        params = []
+        metadata_filter = metadata_filter or {}
+
+        scopes = metadata_filter.get("scopes")
+        if scopes is not None:
+            if not scopes:
+                clauses.append("0")
+            else:
+                clauses.append(
+                    "scope IN ({})".format(",".join("?" for _ in scopes))
+                )
+                params.extend(scopes)
+
+        user_id = metadata_filter.get("user_id")
+        if shared_visible_to_user and user_id:
+            clauses.append("(scope = 'shared' OR user_id = ?)")
+            params.append(user_id)
+
+        for key, value in metadata_filter.items():
+            if key == "scopes" or (
+                key == "user_id" and shared_visible_to_user
+            ) or value is None:
+                continue
+            if key not in cls._FILTER_COLUMNS:
+                raise ValueError("Unsupported vector metadata filter: {}".format(key))
+            clauses.append("{} = ?".format(key))
+            params.append(value)
+        return clauses, params
+
+    @staticmethod
+    def _match(row, score: float) -> VectorMatch:
+        return VectorMatch(
+            id=row["id"],
+            score=score,
+            metadata={
+                "user_id": row["user_id"],
+                "scope": row["scope"],
+                "source": row["source"],
+                "path": row["path"],
+                "start_line": row["start_line"],
+                "end_line": row["end_line"],
+                "text": row["text"],
+                "metadata": json.loads(row["metadata"]) if row["metadata"] else None,
+            },
+        )
+
+    @staticmethod
+    def _encode_embedding(embedding: Optional[Sequence[float]]) -> Optional[bytes]:
+        if embedding is None:
+            return None
+        if _HAS_NUMPY:
+            return np.array(embedding, dtype=np.float32).tobytes()
+        return struct.pack("{}f".format(len(embedding)), *embedding)
+
+    @staticmethod
+    def _decode_embedding(raw) -> Optional[List[float]]:
+        if raw is None:
+            return None
+        if isinstance(raw, (bytes, bytearray)):
+            if _HAS_NUMPY:
+                return np.frombuffer(raw, dtype=np.float32).tolist()
+            count = len(raw) // 4
+            return list(struct.unpack("{}f".format(count), raw))
+        return json.loads(raw)

--- a/tests/test_vector_backend.py
+++ b/tests/test_vector_backend.py
@@ -1,0 +1,133 @@
+from agent.memory.storage import MemoryChunk, MemoryStorage
+from agent.memory.vector_backend import (
+    SQLiteVectorBackend,
+    VectorBackend,
+    VectorMatch,
+    VectorRecord,
+)
+
+
+def _chunk(
+    chunk_id,
+    embedding,
+    *,
+    path="memory/shared/test.md",
+    scope="shared",
+    user_id=None,
+):
+    return MemoryChunk(
+        id=chunk_id,
+        user_id=user_id,
+        scope=scope,
+        source="memory",
+        path=path,
+        start_line=1,
+        end_line=1,
+        text=f"text for {chunk_id}",
+        embedding=embedding,
+        hash=f"hash-{chunk_id}",
+        metadata={"kind": "note"},
+    )
+
+
+def test_sqlite_vector_backend_preserves_filtering_and_score_order(tmp_path):
+    storage = MemoryStorage(tmp_path / "index.db")
+    assert isinstance(storage.vector_backend, SQLiteVectorBackend)
+    storage.save_chunks_batch(
+        [
+            _chunk("shared-best", [1.0, 0.0]),
+            _chunk("shared-second", [0.8, 0.2]),
+            _chunk(
+                "other-user",
+                [1.0, 0.0],
+                path="memory/users/other/test.md",
+                scope="user",
+                user_id="other",
+            ),
+        ]
+    )
+
+    results = storage.search_vector(
+        [1.0, 0.0],
+        user_id="current",
+        scopes=["shared", "user"],
+        limit=10,
+    )
+
+    assert [result.path for result in results] == [
+        "memory/shared/test.md",
+        "memory/shared/test.md",
+    ]
+    assert results[0].score > results[1].score
+    assert storage.get_chunk("shared-best").embedding == [1.0, 0.0]
+    storage.close()
+
+
+class RecordingVectorBackend(VectorBackend):
+    def __init__(self):
+        self.upserted = []
+        self.deleted = []
+        self.search_filter = None
+
+    def upsert(self, records):
+        self.upserted.extend(records)
+
+    def delete(self, ids=None, metadata_filter=None):
+        self.deleted.append((ids, metadata_filter))
+
+    def search(self, query_embedding, limit=10, metadata_filter=None):
+        self.search_filter = metadata_filter
+        return [
+            VectorMatch(
+                id="custom-result",
+                score=0.75,
+                metadata={
+                    "path": "memory/shared/custom.md",
+                    "start_line": 3,
+                    "end_line": 4,
+                    "text": "custom backend text",
+                    "source": "memory",
+                    "user_id": None,
+                },
+            )
+        ]
+
+
+def test_memory_storage_routes_vector_operations_through_backend(tmp_path):
+    backend = RecordingVectorBackend()
+    storage = MemoryStorage(tmp_path / "index.db", vector_backend=backend)
+    chunk = _chunk("custom-result", [0.5, 0.5], path="memory/shared/custom.md")
+
+    storage.save_chunk(chunk)
+    results = storage.search_vector(
+        [0.5, 0.5],
+        user_id="current",
+        scopes=["shared", "user"],
+        limit=4,
+    )
+    storage.delete_by_path(chunk.path)
+
+    assert backend.upserted == [
+        VectorRecord(
+            id="custom-result",
+            embedding=[0.5, 0.5],
+            metadata={
+                "user_id": None,
+                "scope": "shared",
+                "source": "memory",
+                "path": "memory/shared/custom.md",
+                "start_line": 1,
+                "end_line": 1,
+                "text": "text for custom-result",
+                "metadata": {"kind": "note"},
+            },
+        )
+    ]
+    assert backend.search_filter == {
+        "scopes": ["shared", "user"],
+        "user_id": "current",
+    }
+    assert backend.deleted == [(None, {"path": "memory/shared/custom.md"})]
+    assert results[0].path == "memory/shared/custom.md"
+    assert results[0].score == 0.75
+    storage.close()


### PR DESCRIPTION
## Summary

- introduce a narrow `VectorBackend` contract for upsert, delete, search, and metadata filtering
- move the existing SQLite cosine-search implementation into `SQLiteVectorBackend`
- keep SQLite as the zero-dependency default while routing memory vector writes, deletes, and searches through the backend
- preserve the existing `chunks.embedding` schema, FTS5 keyword path, visibility filters, and score ordering

## Scope

This is the abstraction-only first step requested in #2956. It intentionally does not add Milvus, new dependencies, configuration, or schema migration.

## Testing

- `python3 -m pytest tests/test_vector_backend.py tests/test_knowledge_service.py tests/test_search_files_tool.py -q` (`74 passed`)
- `ruff check --select F,I agent/memory/__init__.py agent/memory/storage.py agent/memory/vector_backend.py tests/test_vector_backend.py`
- `ruff check --select E,F,I agent/memory/vector_backend.py tests/test_vector_backend.py`
- `python3 -m compileall -q agent/memory`
- `git diff --check origin/master...HEAD`

Refs #2956