### PR TITLE
feat(image): support custom generation providers

### DIFF
--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -28,7 +28,13 @@ from common import const
 from common import i18n
 from common.log import logger
 from common.singleton import singleton
-from config import conf, get_data_root, get_weixin_credentials_path, read_config_template
+from config import (
+    conf,
+    get_data_root,
+    get_weixin_credentials_path,
+    read_config_template,
+    sync_image_generation_custom_provider_env,
+)
 from models.reasoning_capabilities import provider_reasoning_metadata
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
@@ -3201,6 +3207,7 @@ class ModelsHandler:
             {"value": "gemini-3-pro-image-preview",     "hint": "Nano Banana Pro"},
             "seedream-5.0-lite",
         ],
+        "custom": [],
     }
 
     @staticmethod
@@ -3686,13 +3693,23 @@ class ModelsHandler:
         explicit_model = (img_node.get("model") or "").strip()
         explicit_provider = (img_node.get("provider") or "").strip()
 
+        providers = []
+        custom_cards = cls._custom_provider_cards(local_config)
+        for provider_id in cls._IMAGE_PROVIDER_MODELS:
+            if provider_id == "custom":
+                providers.extend(
+                    card["id"] for card in custom_cards
+                )
+            else:
+                providers.append(provider_id)
+
         # Provider resolution priority:
         #   1. Explicit `skills.image-generation.provider` (persisted via UI;
         #      supports custom model names that prefix-inference can't catch).
         #   2. Scan per-provider model catalog by model name.
         # Empty provider keeps the dropdown on "auto" when we can't tell.
         inferred_provider = ""
-        if explicit_provider and explicit_provider in cls._IMAGE_PROVIDER_MODELS:
+        if explicit_provider and explicit_provider in providers:
             inferred_provider = explicit_provider
         elif explicit_model:
             for pid, models in cls._IMAGE_PROVIDER_MODELS.items():
@@ -3717,13 +3734,9 @@ class ModelsHandler:
             "current_model": explicit_model,
             "fallback_provider": predicted["provider"],
             "fallback_model": predicted["model"],
-            "providers": list(cls._IMAGE_PROVIDER_MODELS.keys()),
+            "providers": providers,
             "provider_models": cls._IMAGE_PROVIDER_MODELS,
-            # The dispatcher that honors a pinned provider isn't wired up
-            # yet; advertise this so the UI can show a "saved but not active"
-            # banner until the runtime catches up.
-            "runtime_active": False,
-            "note": "router_pending",
+            "runtime_active": True,
         }
 
     # Canonical search provider order. Mirrors PROVIDER_ORDER in
@@ -3972,6 +3985,51 @@ class ModelsHandler:
                 if provider and provider.get("model"):
                     local_config["model"] = provider["model"]
                     file_cfg["model"] = provider["model"]
+
+        skills = local_config.get("skills") or {}
+        image_config = (
+            skills.get("image-generation")
+            if isinstance(skills, dict)
+            else {}
+        )
+        image_provider = (
+            image_config.get("provider", "")
+            if isinstance(image_config, dict)
+            else ""
+        )
+        if image_provider.startswith("custom:"):
+            image_provider_id = image_provider[len("custom:"):]
+            if not any(
+                provider.get("id") == image_provider_id
+                for provider in providers
+            ):
+                for target in (local_config, file_cfg):
+                    self._set_nested_namespace_value(
+                        target,
+                        "skills",
+                        "image-generation",
+                        "provider",
+                        "",
+                    )
+                    self._set_nested_namespace_value(
+                        target,
+                        "skills",
+                        "image-generation",
+                        "model",
+                        "",
+                    )
+                os.environ.pop(
+                    "SKILL_IMAGE_GENERATION_PROVIDER",
+                    None,
+                )
+                os.environ.pop(
+                    "SKILL_IMAGE_GENERATION_MODEL",
+                    None,
+                )
+        sync_image_generation_custom_provider_env(
+            local_config,
+            overwrite=True,
+        )
         self._write_file_config(file_cfg)
         self._reset_bridge()
 
@@ -4124,6 +4182,45 @@ class ModelsHandler:
         # a specific vendor still get routed there — runtime falls back to
         # model-name prefix inference only when provider is empty.
         local_config = conf()
+        if provider_id.startswith("custom:"):
+            custom_id = provider_id[len("custom:"):]
+            providers = self._normalize_custom_providers(
+                local_config.get("custom_providers")
+            )
+            custom_provider = next(
+                (
+                    provider
+                    for provider in providers
+                    if provider.get("id") == custom_id
+                ),
+                None,
+            )
+            if custom_provider is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "unknown custom provider id: {}".format(custom_id)
+                    ),
+                })
+            if not model:
+                model = custom_provider.get("model") or ""
+        elif (
+            provider_id
+            and provider_id not in self._IMAGE_PROVIDER_MODELS
+        ):
+            return json.dumps({
+                "status": "error",
+                "message": "unknown image provider: {}".format(provider_id),
+            })
+
+        if provider_id and not model:
+            return json.dumps({
+                "status": "error",
+                "message": (
+                    "image model is required when a provider is selected"
+                ),
+            })
+
         file_cfg = self._read_file_config()
 
         self._set_nested_namespace_value(local_config, "skills", "image-generation", "model", model or "")
@@ -4148,13 +4245,16 @@ class ModelsHandler:
             os.environ[provider_env] = provider_id
         else:
             os.environ.pop(provider_env, None)
+        sync_image_generation_custom_provider_env(
+            local_config,
+            overwrite=True,
+        )
 
         logger.info(f"[ModelsHandler] image updated: provider={provider_id!r} model={model!r}")
         return json.dumps({
             "status": "success",
             "provider": provider_id,
             "model": model,
-            "router_pending": True,
         })
 
     def _set_chat(self, provider_id: str, model: str) -> str:

--- a/config.py
+++ b/config.py
@@ -570,6 +570,7 @@ def load_config():
                 injected += 1
 
     injected += _sync_skill_config_to_env(config.get("skills", {}))
+    injected += sync_image_generation_custom_provider_env(config)
 
     if injected:
         logger.info("[INIT] Synced {} config values to environment variables".format(injected))
@@ -684,6 +685,55 @@ def _sync_skill_config_to_env(skill_section) -> int:
             os.environ[env_key] = str(val)
             injected += 1
     return injected
+
+
+def sync_image_generation_custom_provider_env(
+    config_data,
+    overwrite=False,
+) -> int:
+    """Expose the selected custom image provider to the skill subprocess."""
+    env_key = "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER"
+    skills = config_data.get("skills") if isinstance(config_data, dict) else {}
+    image_config = (
+        skills.get("image-generation")
+        if isinstance(skills, dict)
+        else {}
+    )
+    provider_id = (
+        image_config.get("provider", "")
+        if isinstance(image_config, dict)
+        else ""
+    )
+
+    selected = None
+    if isinstance(provider_id, str) and provider_id.startswith("custom:"):
+        custom_id = provider_id[len("custom:"):]
+        providers = config_data.get("custom_providers", [])
+        if isinstance(providers, list):
+            selected = next(
+                (
+                    provider
+                    for provider in providers
+                    if isinstance(provider, dict)
+                    and provider.get("id") == custom_id
+                ),
+                None,
+            )
+
+    if selected is None:
+        if overwrite:
+            os.environ.pop(env_key, None)
+        return 0
+    if env_key in os.environ and not overwrite:
+        return 0
+
+    payload = {
+        key: selected.get(key)
+        for key in ("id", "name", "api_key", "api_base", "model")
+        if selected.get(key) is not None
+    }
+    os.environ[env_key] = json.dumps(payload, ensure_ascii=False)
+    return 1
 
 
 def get_root():

--- a/skills/image-generation/scripts/generate.py
+++ b/skills/image-generation/scripts/generate.py
@@ -1023,6 +1023,8 @@ _PROVIDER_ID_TO_LABEL = {
     "linkai": "LinkAI",
 }
 
+_CUSTOM_PROVIDER_ENV = "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER"
+
 
 def _preferred_provider(model: str) -> str | None:
     m = (model or "").lower()
@@ -1030,6 +1032,38 @@ def _preferred_provider(model: str) -> str | None:
         if m.startswith(prefixes):
             return label
     return None
+
+
+def _build_custom_provider(
+    provider_id: str,
+    model: str,
+) -> tuple[str, ImageProvider] | None:
+    """Build the selected OpenAI-compatible custom image provider."""
+    try:
+        config = json.loads(os.environ.get(_CUSTOM_PROVIDER_ENV, ""))
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(config, dict):
+        return None
+
+    custom_id = provider_id[len("custom:"):]
+    if config.get("id") != custom_id:
+        return None
+    api_key = (config.get("api_key") or "").strip()
+    api_base = (config.get("api_base") or "").strip()
+    selected_model = model or (config.get("model") or "").strip()
+    if not api_key or not api_base or not selected_model:
+        return None
+
+    label = (config.get("name") or provider_id).strip()
+    return (
+        label,
+        OpenAIProvider(
+            api_key=api_key,
+            api_base=api_base,
+            model=selected_model,
+        ),
+    )
 
 
 def _build_providers(model: str, provider_id: str = "") -> list[tuple[str, ImageProvider]]:
@@ -1046,6 +1080,10 @@ def _build_providers(model: str, provider_id: str = "") -> list[tuple[str, Image
          model and fall back to automatic routing — every provider then uses
          its own DEFAULT_MODEL.
     """
+    if provider_id.startswith("custom:"):
+        provider = _build_custom_provider(provider_id, model)
+        return [provider] if provider else []
+
     keys = {
         "OpenAI": os.environ.get("OPENAI_API_KEY", ""),
         "Gemini": os.environ.get("GEMINI_API_KEY", ""),
@@ -1143,6 +1181,15 @@ def main():
 
     providers = _build_providers(model, provider_id=provider_id)
     if not providers:
+        if provider_id.startswith("custom:"):
+            print(json.dumps({
+                "error": (
+                    "The selected custom image provider is missing or "
+                    "has no API key, API base, or model configured. "
+                    "Update it in the Models settings before retrying."
+                )
+            }, ensure_ascii=False))
+            sys.exit(1)
         target = f"model '{model}'" if model else "image generation"
         print(json.dumps({
             "error": (

--- a/tests/test_custom_provider_handlers.py
+++ b/tests/test_custom_provider_handlers.py
@@ -15,6 +15,7 @@ import os
 import sys
 import types
 import unittest
+from unittest.mock import patch
 
 # Add project root to path.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -283,6 +284,131 @@ class TestProviderOverviewExpansion(unittest.TestCase):
         cards = ModelsHandler._custom_provider_cards(config_module.conf())
         active_cards = [c for c in cards if c.get("active")]
         self.assertEqual(len(active_cards), 0)
+
+
+class TestCustomImageProvider(unittest.TestCase):
+    def setUp(self):
+        self.provider = {
+            "id": "image_vendor",
+            "name": "image-vendor",
+            "api_key": "image-key",
+            "api_base": "https://images.example.com/v1",
+            "model": "vendor-image-model",
+        }
+        set_conf({
+            "custom_providers": [self.provider],
+            "skills": {
+                "image-generation": {
+                    "provider": "custom:image_vendor",
+                    "model": "vendor-image-model",
+                },
+            },
+        })
+
+    def test_image_capability_exposes_custom_provider(self):
+        cap = ModelsHandler._image_capability(config_module.conf())
+
+        self.assertIn("custom:image_vendor", cap["providers"])
+        self.assertEqual(cap["current_provider"], "custom:image_vendor")
+        self.assertEqual(cap["provider_models"]["custom"], [])
+        self.assertTrue(cap["runtime_active"])
+        self.assertNotIn("note", cap)
+
+    def test_set_image_uses_custom_provider_default_model(self):
+        handler = ModelsHandler.__new__(ModelsHandler)
+        file_config = {"custom_providers": [self.provider]}
+        handler._read_file_config = lambda: file_config
+        handler._write_file_config = lambda data: None
+
+        with patch.dict(os.environ, {}, clear=False):
+            result = json.loads(
+                handler._set_image("custom:image_vendor", "")
+            )
+            payload = json.loads(
+                os.environ["SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER"]
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["model"], "vendor-image-model")
+        self.assertEqual(payload["id"], "image_vendor")
+        self.assertEqual(payload["api_base"], "https://images.example.com/v1")
+        self.assertEqual(
+            file_config["skills"]["image-generation"]["provider"],
+            "custom:image_vendor",
+        )
+
+    def test_set_image_rejects_unknown_custom_provider(self):
+        handler = ModelsHandler.__new__(ModelsHandler)
+        result = json.loads(handler._set_image("custom:missing", "model"))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("unknown custom provider", result["message"])
+
+    def test_editing_selected_provider_refreshes_skill_environment(self):
+        handler = ModelsHandler.__new__(ModelsHandler)
+        handler._read_file_config = lambda: {}
+        handler._write_file_config = lambda data: None
+        handler._reset_bridge = lambda: None
+        updated = dict(
+            self.provider,
+            api_key="new-key",
+            api_base="https://new.example.com/v1",
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            handler._persist_custom_providers([updated])
+            payload = json.loads(
+                os.environ["SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER"]
+            )
+
+        self.assertEqual(payload["api_key"], "new-key")
+        self.assertEqual(
+            payload["api_base"],
+            "https://new.example.com/v1",
+        )
+
+    def test_deleting_selected_provider_clears_image_route(self):
+        handler = ModelsHandler.__new__(ModelsHandler)
+        file_config = {
+            "custom_providers": [self.provider],
+            "skills": {
+                "image-generation": {
+                    "provider": "custom:image_vendor",
+                    "model": "vendor-image-model",
+                },
+            },
+        }
+        handler._read_file_config = lambda: file_config
+        handler._write_file_config = lambda data: None
+        handler._reset_bridge = lambda: None
+        env = {
+            "SKILL_IMAGE_GENERATION_PROVIDER": "custom:image_vendor",
+            "SKILL_IMAGE_GENERATION_MODEL": "vendor-image-model",
+            "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER": json.dumps(
+                self.provider
+            ),
+        }
+
+        with patch.dict(os.environ, env, clear=False):
+            handler._persist_custom_providers([])
+
+            image_config = config_module.conf()["skills"][
+                "image-generation"
+            ]
+            self.assertEqual(image_config["provider"], "")
+            self.assertEqual(image_config["model"], "")
+            self.assertNotIn(
+                "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER",
+                os.environ,
+            )
+            self.assertNotIn(
+                "SKILL_IMAGE_GENERATION_PROVIDER",
+                os.environ,
+            )
+            self.assertNotIn(
+                "SKILL_IMAGE_GENERATION_MODEL",
+                os.environ,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_image_generation_custom_provider.py
+++ b/tests/test_image_generation_custom_provider.py
@@ -1,0 +1,98 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+from config import sync_image_generation_custom_provider_env
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "image-generation"
+    / "scripts"
+    / "generate.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "image_generation_script",
+    SCRIPT_PATH,
+)
+image_generation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(image_generation)
+
+
+def _config():
+    return {
+        "custom_providers": [
+            {
+                "id": "image_vendor",
+                "name": "image-vendor",
+                "api_key": "image-key",
+                "api_base": "https://images.example.com/v1",
+                "model": "vendor-image-model",
+            },
+        ],
+        "skills": {
+            "image-generation": {
+                "provider": "custom:image_vendor",
+                "model": "vendor-image-model",
+            },
+        },
+    }
+
+
+def test_sync_selected_custom_image_provider_to_env(monkeypatch):
+    monkeypatch.delenv(
+        "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER",
+        raising=False,
+    )
+
+    assert sync_image_generation_custom_provider_env(_config()) == 1
+
+    payload = json.loads(
+        os.environ["SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER"]
+    )
+    assert payload == {
+        "id": "image_vendor",
+        "name": "image-vendor",
+        "api_key": "image-key",
+        "api_base": "https://images.example.com/v1",
+        "model": "vendor-image-model",
+    }
+
+
+def test_build_providers_uses_explicit_custom_provider(monkeypatch):
+    monkeypatch.setenv(
+        "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER",
+        json.dumps(_config()["custom_providers"][0]),
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "fallback-key")
+
+    providers = image_generation._build_providers(
+        "vendor-image-model",
+        provider_id="custom:image_vendor",
+    )
+
+    assert len(providers) == 1
+    label, provider = providers[0]
+    assert label == "image-vendor"
+    assert isinstance(provider, image_generation.OpenAIProvider)
+    assert provider.api_key == "image-key"
+    assert provider.api_base == "https://images.example.com/v1"
+    assert provider.model == "vendor-image-model"
+
+
+def test_build_providers_does_not_fallback_for_missing_custom_provider(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        "SKILL_IMAGE_GENERATION_CUSTOM_PROVIDER",
+        raising=False,
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "fallback-key")
+
+    providers = image_generation._build_providers(
+        "vendor-image-model",
+        provider_id="custom:missing",
+    )
+
+    assert providers == []


### PR DESCRIPTION
## Summary

- expose configured `custom:<id>` providers in the image-generation capability picker
- validate and persist the selected custom provider and model, including the provider's default model
- route the standalone image-generation skill through the selected provider's OpenAI-compatible image endpoints
- refresh selected credentials after provider edits and clear stale image routing when that provider is deleted

The existing image-generation skill already handles both text-to-image and image-to-image requests, so this PR wires custom vendors into that path instead of adding a duplicate channel.

## Scope

- no new dependency or config schema
- only the currently selected custom provider is exported to the skill subprocess
- explicit custom routing never silently falls back to another vendor
- built-in provider routing remains unchanged

## Testing

- `python3 -m pytest tests/test_custom_provider_handlers.py tests/test_custom_provider.py tests/test_models_handler.py tests/test_image_generation_custom_provider.py tests/test_bash_config_propagation.py tests/test_config_subagent_toggle.py -q` (`73 passed`)
- full-suite baseline comparison: branch `761 passed, 32 failed, 3 skipped`; clean `origin/master` `753 passed, 32 failed, 3 skipped`, with an identical pre-existing failure list
- `python3 -m compileall -q config.py channel/web/web_channel.py skills/image-generation/scripts/generate.py`
- `ruff check --select E,F,I tests/test_image_generation_custom_provider.py`
- `git diff --check`

Closes #2881