### PR TITLE
fix: keep thinking/CoT blocks off IM Agent Reply

### DIFF
--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -1266,8 +1266,36 @@ class AgentStreamExecutor:
                         if self._is_thinking_enabled():
                             self._emit_event("reasoning_update", {"delta": reasoning_delta})
 
-                    # Handle text content
+                    # Handle text content. Some providers (Anthropic-shaped
+                    # adapters, MiMo sync wrappers) stream a list of content
+                    # blocks instead of a string. Thinking/reasoning blocks
+                    # must never be treated as the visible reply — that is
+                    # what leaked CoT into WeChat as "Agent Reply".
                     content_delta = delta.get("content") or ""
+                    if isinstance(content_delta, list):
+                        text_parts = []
+                        for block in content_delta:
+                            if not isinstance(block, dict):
+                                continue
+                            btype = block.get("type")
+                            if btype in ("thinking", "reasoning"):
+                                thinking_text = (
+                                    block.get("thinking")
+                                    or block.get("reasoning")
+                                    or block.get("text")
+                                    or ""
+                                )
+                                if thinking_text:
+                                    full_reasoning += thinking_text
+                                    if self._is_thinking_enabled():
+                                        self._emit_event(
+                                            "reasoning_update",
+                                            {"delta": thinking_text},
+                                        )
+                                continue
+                            if btype in ("text", "text_delta", None):
+                                text_parts.append(block.get("text") or "")
+                        content_delta = "".join(text_parts)
                     if content_delta:
                         # Filter out <think> tags from content
                         filtered_delta = self._filter_think_tags(content_delta)

--- a/bridge/agent_event_handler.py
+++ b/bridge/agent_event_handler.py
@@ -28,6 +28,7 @@ class AgentEventHandler:
         channel_type = ""
         if context and hasattr(context, "kwargs"):
             channel_type = context.kwargs.get("channel_type", "") or ""
+        self._channel_type = channel_type
         self._is_weixin = channel_type == const.WEIXIN
         self._thinking_sent_count = 0
         self._merged_buf: list[str] = []
@@ -68,7 +69,11 @@ class AgentEventHandler:
         if tool_calls:
             if self.current_content.strip():
                 logger.info(f"💭 {self.current_content.strip()[:200]}{'...' if len(self.current_content) > 200 else ''}")
-                self._send_to_channel(self.current_content.strip())
+                # Only the Web console renders intermediate pre-tool
+                # commentary. IM channels (WeChat/WeCom/DingTalk/Feishu/...)
+                # must not receive CoT as a visible "Agent Reply".
+                if self._channel_type == "web":
+                    self._send_to_channel(self.current_content.strip())
         else:
             if self.current_content.strip():
                 logger.debug(f"💬 {self.current_content.strip()[:200]}{'...' if len(self.current_content) > 200 else ''}")

--- a/tests/test_agent_event_handler.py
+++ b/tests/test_agent_event_handler.py
@@ -1,0 +1,46 @@
+from common import const
+from bridge.agent_event_handler import AgentEventHandler
+
+
+class _FakeChannel:
+    def __init__(self):
+        self.sent = []
+
+    def _send(self, reply, context):
+        self.sent.append(reply.content)
+
+
+class _FakeContext:
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+
+    def get(self, key, default=None):
+        return default
+
+
+def _context(channel_type, channel):
+    return _FakeContext({"channel": channel, "channel_type": channel_type})
+
+
+def test_weixin_does_not_forward_pre_tool_thinking_as_reply():
+    channel = _FakeChannel()
+    handler = AgentEventHandler(_context(const.WEIXIN, channel))
+    handler.handle_event({"type": "turn_start", "data": {"turn": 1}})
+    handler.handle_event({"type": "message_update", "data": {"delta": "I should call a tool..."}})
+    handler.handle_event({
+        "type": "message_end",
+        "data": {"tool_calls": [{"id": "call_1", "name": "search"}], "content": "I should call a tool..."},
+    })
+    assert channel.sent == []
+
+
+def test_web_still_forwards_pre_tool_commentary():
+    channel = _FakeChannel()
+    handler = AgentEventHandler(_context("web", channel))
+    handler.handle_event({"type": "turn_start", "data": {"turn": 1}})
+    handler.handle_event({"type": "message_update", "data": {"delta": "Looking that up."}})
+    handler.handle_event({
+        "type": "message_end",
+        "data": {"tool_calls": [{"id": "call_1", "name": "search"}], "content": "Looking that up."},
+    })
+    assert channel.sent == ["Looking that up."]


### PR DESCRIPTION
## Summary
- MiMo / Anthropic-shaped streams can deliver thinking as content blocks (`type: thinking|reasoning`). Those were concatenated into `message_update` and then forwarded to WeChat as an Agent Reply.
- Route thinking/reasoning blocks to `reasoning_update`, and stop sending pre-tool commentary to IM channels (WeChat/WeCom/etc.). Web still shows intermediate commentary.
- Adds tests covering WeChat vs Web `message_end` behavior.

Fixes https://github.com/zhayujie/CowAgent/issues/3026

## Test plan
- [x] `python -m pytest tests/test_agent_event_handler.py -q`
- [ ] WeChat + MiMo v2.5 with thinking enabled: CoT stays off the chat, final answer still arrives
- [ ] Web console still shows the collapsible thinking panel

Made with [Cursor](https://cursor.com)