### PR TITLE
fix: In Windows drive navigation in workspace folder picker

### DIFF
--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -40,6 +40,9 @@ from models.reasoning_capabilities import provider_reasoning_metadata
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
 VIDEO_EXTENSIONS = {".mp4", ".webm", ".avi", ".mov", ".mkv"}
 
+# Windows need
+import sys
+import ctypes
 
 @dataclass
 class SSEStreamState:
@@ -6278,6 +6281,23 @@ class ProjectBrowseHandler:
             from common.utils import expand_path
             params = web.input(path='')
             raw = (params.path or '').strip()
+
+            # In Windows,If the path is __DRIVES__, we return a list of drives.
+            if sys.platform == 'win32' and raw == '__DRIVES__':
+                drives = []
+                buf = ctypes.create_unicode_buffer(1024)
+                length = ctypes.windll.kernel32.GetLogicalDriveStringsW(1024, buf)
+                for drive in buf[:length].split('\x00'):
+                    if drive:
+                        drives.append({"name": drive.rstrip('\\'), "path": drive})
+
+                return json.dumps({
+                    "status": "success",
+                    "path": "Drives:",
+                    "parent": None,
+                    "dirs": drives
+                }, ensure_ascii=False)
+            
             # Default entry point is the user's home (~), a familiar anchor for
             # picking a project directory.
             base = os.path.realpath(expand_path(raw)) if raw else os.path.realpath(os.path.expanduser("~"))
@@ -6303,6 +6323,14 @@ class ProjectBrowseHandler:
 
             dirs.sort(key=lambda d: d["name"].lower())
             parent = os.path.dirname(base)
+
+            # In Windows, if the current directory is the root directory of the drive:
+            if sys.platform == 'win32':
+                drive,tail = os.path.splitdrive(base)
+                if tail in (os.sep, os.altsep) or tail == '':
+                    # Set parent to __DRIVES__
+                    parent = '__DRIVES__'
+
             return json.dumps({
                 "status": "success",
                 "path": base,


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

This PR fixes the inability to navigate to the drive list when the user is at a Windows drive root (e.g., C:\\) in the workspace folder picker. It introduces a virtual path `__DRIVES__` that the backend recognises and responds with a list of all available drives. The frontend can then display these drives as selectable folders, allowing the user to switch between drives seamlessly.
Check for `sys.platform == 'win32'` has been added; this will not affect the function's behavior on other systems.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): closes #3047 
